### PR TITLE
Use SpatialUIController's internal DotController

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@ import p5 from 'https://jspm.dev/p5@1.6.0';
 
 import TimerManager from './managers/timerManager.js';
 import SequenceManager from './managers/sequenceManager.js';
-import DotController from './controllers/dotController.js';
 import SystemUIController from './ui/systemUIController.js';
 import CanvasRenderer from './render/canvasRenderer.js';
 import SpatialUIController from './ui/spatialUIController.js';
@@ -20,9 +19,6 @@ new p5((p) => {
   };
 
   p.setup = () => {
-    const weightController  = new DotController(sequences, 'weight');
-    const gestureController = new DotController(sequences, 'gesture');
-
     canvas    = new CanvasRenderer(p);
     canvas.init();
 
@@ -31,8 +27,6 @@ new p5((p) => {
     systemUI  = new SystemUIController(p, {
       timer,
       sequences,
-      weightController,
-      gestureController,
       canvasRenderer: canvas,
       spatialUIController: spatialUI,
     });

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -8,8 +8,6 @@ export default class SystemUIController {
     p,
     {
       timer,
-      weightController,
-      gestureController,
       canvasRenderer,
       spatialUIController,
       sequences, // preloaded SequenceManager
@@ -17,8 +15,6 @@ export default class SystemUIController {
   ) {
     this.p = p;
     this.timer = timer;
-    this.weightController = weightController;
-    this.gestureController = gestureController;
     this.canvasRenderer = canvasRenderer;
     this.spatialUIController = spatialUIController;
     this.sequenceManager = sequences;


### PR DESCRIPTION
## Summary
- Remove standalone dot controller instances from `main.js` and rely on `SpatialUIController`'s internal `DotController`.
- Simplify `SystemUIController` constructor by dropping unused `weightController` and `gestureController` parameters.
- Maintain dot interaction flow via `SpatialUIController.dotController` for sequencing and advancement.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894de79d49c8332a45aa6475497174c