### PR TITLE
chore: remove canvas option from dot controller

### DIFF
--- a/src/controllers/dotController.js
+++ b/src/controllers/dotController.js
@@ -6,10 +6,7 @@ export default class DotController {
    * @param {object} config.positionMap   token → {x,y}
    * @param {number} [config.moveDurationMs=500] duration of each leg
    */
-  constructor(
-    p,
-    { positionMap: gesturePositions, moveDurationMs = 500, canvas = null }
-  ) {
+  constructor(p, { positionMap: gesturePositions, moveDurationMs = 500 }) {
     this.p = p;
     this.gesturePositions = gesturePositions;
 

--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -231,7 +231,6 @@ export default class SpatialUIController {
     this.dotController = new DotController(this.p, {
       positionMap: gesturePositions,
       moveDurationMs: 500,
-      canvas: this.canvas,
     });
     this.dotController.loadSequence(['C', 'C.U', 'C.D', 'C.L', 'C.R']);
   }


### PR DESCRIPTION
## Summary
- drop unused canvas option from dotController constructor
- stop passing canvas when creating dotController in spatialUIController

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894decfa55c83329fc8d206e8989a51