### PR TITLE
refactor: use button panel tempo input

### DIFF
--- a/src/ui/buttonPanelController.js
+++ b/src/ui/buttonPanelController.js
@@ -64,6 +64,11 @@ export default class ButtonPanelController {
     return this.tempoInput.value();
   }
 
+  // Setter to allow SystemUIController to update the input
+  setTempoValue(value) {
+    this.tempoInput.value(`${value}`);
+  }
+
   updateTimerModeLabel(text) {
     this.buttons.toggleTimerMode.html(text);
   }

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -197,7 +197,7 @@ export default class SystemUIController {
     if (!isNaN(cfg.tempo)) {
       this.tempo = cfg.tempo;
       this.timer.setTempo(cfg.tempo);
-      this.buttonPanel.tempoInput.value(cfg.tempo);
+      this.buttonPanel.setTempoValue(cfg.tempo);
     }
     if (!isNaN(cfg.duration)) {
       this.duration = cfg.duration;


### PR DESCRIPTION
## Summary
- avoid direct tempo input references in `SystemUIController`
- add tempo setter to `ButtonPanelController`
- apply group tempo through the button panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --experimental-default-type=module tempoTest.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6894e46c3a908332ae738a55cdb638a2