### PR TITLE
Rename weight object prefix to W.L and move weight buttons left

### DIFF
--- a/config.js
+++ b/config.js
@@ -118,7 +118,7 @@ export const FALLBACK_WEIGHT_SEQ = [
   'LL',
   'LDL',
 ];
-export const FALLBACK_GESTURE_SEQ = ['X.R', 'X.D', 'X.L', 'X.U'];
+export const FALLBACK_GESTURE_SEQ = ['W.L.R', 'W.L.D', 'W.L.L', 'W.L.U'];
 
 // ——— (Later) CSV filename ———
 export const SEQUENCE_CSV_PATH = 'sequences - Sheet1.csv';

--- a/src/assets/sequences.tsv
+++ b/src/assets/sequences.tsv
@@ -1,16 +1,16 @@
  1	States	Whole	Off	60	8				
 	Beat	1	2	3	4	5	6	7	8
 	Gesture	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U
-	Weight	X.U	X.D	X.U	X.D	X.U	X.D	X.U	X.D
+	Weight	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D
 2	States	Whole	Off	60	4				
 	Beat	1	2	3	4				
 	Gesture	L	LR	L	LR				
-	Weight	X.RU	X.LU	X.LD	X.RD				
+	Weight	W.L.RU	W.L.LU	W.L.LD	W.L.RD				
 3	States	Whole	Off	60	8				
 	Beat	1	2	3	4	5	6	7	8
 	Gesture	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U
-	Weight	X.U	X.D	X.U	X.D	X.U	X.D	X.U	X.D
+	Weight	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D
 4	 States	Whole	Off	60	4				
 	Beat	1	2	3	4				
 	Gesture	L	LR	L	LR				
-	Weight	X.RU	X.LU	X.LD	X.RD				
+	Weight	W.L.RU	W.L.LU	W.L.LD	W.L.RD				

--- a/src/controllers/orbController.js
+++ b/src/controllers/orbController.js
@@ -19,8 +19,8 @@ export default class OrbController {
   /**
    * Highlight one of the eight directional sectors.
    * @param {string} section
-   *        one of 'X.U', 'X.D', 'X.L', 'X.R',
-   *        'X.LU', 'X.RU', 'X.LD', 'X.RD'
+   *        one of 'W.L.U', 'W.L.D', 'W.L.L', 'W.L.R',
+   *        'W.L.LU', 'W.L.RU', 'W.L.LD', 'W.L.RD'
    */
   setHighlight(section) {
     this.highlightedSection = section;
@@ -49,29 +49,29 @@ export default class OrbController {
     if (this.highlightedSection) {
       p.fill(200, 80, 230, 220);
       switch (this.highlightedSection) {
-        case 'X.U':
+        case 'W.L.U':
           p.arc(0, 0, d, d, p.PI, 0, p.PIE);
           break;
-        case 'X.D':
+        case 'W.L.D':
           p.arc(0, 0, d, d, 0, p.PI, p.PIE);
           break;
-        case 'X.R':
+        case 'W.L.R':
           p.arc(0, 0, d, d, -p.HALF_PI, p.HALF_PI, p.PIE);
           break;
-        case 'X.L':
+        case 'W.L.L':
           p.arc(0, 0, d, d, p.HALF_PI, 3 * p.HALF_PI, p.PIE);
           break;
-        case 'X.LU':
+        case 'W.L.LU':
           p.arc(0, 0, d, d, p.PI, 3 * p.HALF_PI, p.PIE);
           break;
-        case 'X.RU':
+        case 'W.L.RU':
           p.arc(0, 0, d, d, 3 * p.HALF_PI, p.TWO_PI, p.PIE);
           break;
-        case 'X.LD':
+        case 'W.L.LD':
           p.arc(0, 0, d, d, p.HALF_PI, p.PI, p.PIE);
 
           break;
-        case 'X.RD':
+        case 'W.L.RD':
           p.arc(0, 0, d, d, 0, p.HALF_PI, p.PIE);
           break;
       }

--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -185,7 +185,7 @@ export default class SpatialUIController {
     Object.entries({
       position: 'fixed',
       top: '100px',
-      right: '20px',
+      left: '20px',
       display: 'grid',
       'grid-template-columns': 'repeat(3, 40px)',
       'grid-gap': '5px',
@@ -198,15 +198,15 @@ export default class SpatialUIController {
     });
 
     const weightNames = [
-      'X.LU',
-      'X.U',
-      'X.RU',
-      'X.L',
-      'X',
-      'X.R',
-      'X.LD',
-      'X.D',
-      'X.RD',
+      'W.L.LU',
+      'W.L.U',
+      'W.L.RU',
+      'W.L.L',
+      'W.L',
+      'W.L.R',
+      'W.L.LD',
+      'W.L.D',
+      'W.L.RD',
     ];
     weightNames.forEach((name) => {
       const btn = p.createButton('');
@@ -215,7 +215,7 @@ export default class SpatialUIController {
       btn.style('border', '1px solid #800080');
       btn.style('border-radius', '5px');
       btn.style('font-size', '8px');
-      btn.html(name.replace('X.', ''));
+      btn.html(name.replace('W.L.', ''));
       btn.parent(this.weightObjectButtonContainer);
       btn.mousePressed(() => {}); // wired later
       this.weightObjectButtons[name] = btn;

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -117,7 +117,7 @@ export default class SystemUIController {
       if (len > 0) {
         const token = this.weightSequence[this.weightIndex];
         const suffix = token.includes('.') ? token.split('.')[1] : '';
-        const section = suffix ? `X.${suffix}` : 'X';
+        const section = suffix ? `W.L.${suffix}` : 'W.L';
         this.spatialUIController.orbController.setHighlight(section);
         this.weightIndex = (this.weightIndex + 1) % len;
       }
@@ -157,7 +157,7 @@ export default class SystemUIController {
     if (this.weightSequence.length > 0) {
       const first = this.weightSequence[0];
       const suffix = first.includes('.') ? first.split('.')[1] : '';
-      const section = suffix ? `X.${suffix}` : 'X';
+      const section = suffix ? `W.L.${suffix}` : 'W.L';
       this.spatialUIController.orbController.setHighlight(section);
     }
     this.weightIndex = this.weightSequence.length > 1 ? 1 : 0;


### PR DESCRIPTION
## Summary
- Rename weight object and related directions from `X` to `W.L`
- Update weight sequences and fallback gesture constants to new `W.L` prefix
- Move weight-button grid to the left side of the screen for L-associated controls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a75f6b94208332ad3484e87b775cdf