### PR TITLE
Add dual orb support with right-side gesture clusters

### DIFF
--- a/config.js
+++ b/config.js
@@ -117,8 +117,35 @@ export const FALLBACK_WEIGHT_SEQ = [
   'LUL',
   'LL',
   'LDL',
+  'R.R',
+  'R.D',
+  'R.L',
+  'R.U',
+  'RU.R',
+  'RU.D',
+  'RU.L',
+  'RU.U',
+  'RD.R',
+  'RD.D',
+  'RD.L',
+  'RD.U',
+  'RUR',
+  'RR',
+  'RDR',
+  'RUL',
+  'RL',
+  'RDL',
 ];
-export const FALLBACK_GESTURE_SEQ = ['W.L.R', 'W.L.D', 'W.L.L', 'W.L.U'];
+export const FALLBACK_GESTURE_SEQ = [
+  'W.L.R',
+  'W.L.D',
+  'W.L.L',
+  'W.L.U',
+  'W.R.R',
+  'W.R.D',
+  'W.R.L',
+  'W.R.U',
+];
 
 // ——— (Later) CSV filename ———
 export const SEQUENCE_CSV_PATH = 'sequences - Sheet1.csv';

--- a/src/assets/sequences.tsv
+++ b/src/assets/sequences.tsv
@@ -1,16 +1,32 @@
- 1	States	Whole	Off	60	8				
-	Beat	1	2	3	4	5	6	7	8
-	Gesture	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U
-	Weight	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D
-2	States	Whole	Off	60	4				
-	Beat	1	2	3	4				
-	Gesture	L	LR	L	LR				
-	Weight	W.L.RU	W.L.LU	W.L.LD	W.L.RD				
-3	States	Whole	Off	60	8				
-	Beat	1	2	3	4	5	6	7	8
-	Gesture	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U	LUL.U	LUR.U
-	Weight	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D	W.L.U	W.L.D
-4	 States	Whole	Off	60	4				
-	Beat	1	2	3	4				
-	Gesture	L	LR	L	LR				
-	Weight	W.L.RU	W.L.LU	W.L.LD	W.L.RD				
+1      States  Whole   Off     60      8
+        Beat    1       2       3       4       5       6       7       8
+        Gesture LUL.U   LUR.U   LUL.U   LUR.U   LUL.U   LUR.U   LUL.U   LUR.U
+        Weight  W.L.U   W.L.D   W.L.U   W.L.D   W.L.U   W.L.D   W.L.U   W.L.D
+2       States  Whole   Off     60      4
+        Beat    1       2       3       4
+        Gesture L       LR      L       LR
+        Weight  W.L.RU  W.L.LU  W.L.LD  W.L.RD
+3       States  Whole   Off     60      8
+        Beat    1       2       3       4       5       6       7       8
+        Gesture LUL.U   LUR.U   LUL.U   LUR.U   LUL.U   LUR.U   LUL.U   LUR.U
+        Weight  W.L.U   W.L.D   W.L.U   W.L.D   W.L.U   W.L.D   W.L.U   W.L.D
+4        States Whole   Off     60      4
+        Beat    1       2       3       4
+        Gesture L       LR      L       LR
+        Weight  W.L.RU  W.L.LU  W.L.LD  W.L.RD
+5       States  Whole   Off     60      8
+        Beat    1       2       3       4       5       6       7       8
+        Gesture RUL.U   RUR.U   RUL.U   RUR.U   RUL.U   RUR.U   RUL.U   RUR.U
+        Weight  W.R.U   W.R.D   W.R.U   W.R.D   W.R.U   W.R.D   W.R.U   W.R.D
+6       States  Whole   Off     60      4
+        Beat    1       2       3       4
+        Gesture R       RR      R       RR
+        Weight  W.R.RU  W.R.LU  W.R.LD  W.R.RD
+7       States  Whole   Off     60      8
+        Beat    1       2       3       4       5       6       7       8
+        Gesture RUL.U   RUR.U   RUL.U   RUR.U   RUL.U   RUR.U   RUL.U   RUR.U
+        Weight  W.R.U   W.R.D   W.R.U   W.R.D   W.R.U   W.R.D   W.R.U   W.R.D
+8        States Whole   Off     60      4
+        Beat    1       2       3       4
+        Gesture R       RR      R       RR
+        Weight  W.R.RU  W.R.LU  W.R.LD  W.R.RD

--- a/src/controllers/orbController.js
+++ b/src/controllers/orbController.js
@@ -20,7 +20,8 @@ export default class OrbController {
    * Highlight one of the eight directional sectors.
    * @param {string} section
    *        one of 'W.L.U', 'W.L.D', 'W.L.L', 'W.L.R',
-   *        'W.L.LU', 'W.L.RU', 'W.L.LD', 'W.L.RD'
+   *        'W.L.LU', 'W.L.RU', 'W.L.LD', 'W.L.RD',
+   *        or the corresponding 'W.R.*' tokens.
    */
   setHighlight(section) {
     this.highlightedSection = section;
@@ -47,33 +48,36 @@ export default class OrbController {
 
     // draw the highlighted slice, if any
     if (this.highlightedSection) {
-      p.fill(200, 80, 230, 220);
-      switch (this.highlightedSection) {
-        case 'W.L.U':
-          p.arc(0, 0, d, d, p.PI, 0, p.PIE);
-          break;
-        case 'W.L.D':
-          p.arc(0, 0, d, d, 0, p.PI, p.PIE);
-          break;
-        case 'W.L.R':
-          p.arc(0, 0, d, d, -p.HALF_PI, p.HALF_PI, p.PIE);
-          break;
-        case 'W.L.L':
-          p.arc(0, 0, d, d, p.HALF_PI, 3 * p.HALF_PI, p.PIE);
-          break;
-        case 'W.L.LU':
-          p.arc(0, 0, d, d, p.PI, 3 * p.HALF_PI, p.PIE);
-          break;
-        case 'W.L.RU':
-          p.arc(0, 0, d, d, 3 * p.HALF_PI, p.TWO_PI, p.PIE);
-          break;
-        case 'W.L.LD':
-          p.arc(0, 0, d, d, p.HALF_PI, p.PI, p.PIE);
-
-          break;
-        case 'W.L.RD':
-          p.arc(0, 0, d, d, 0, p.HALF_PI, p.PIE);
-          break;
+      const parts = this.highlightedSection.split('.');
+      const dir = parts[2];
+      if (dir) {
+        p.fill(200, 80, 230, 220);
+        switch (dir) {
+          case 'U':
+            p.arc(0, 0, d, d, p.PI, 0, p.PIE);
+            break;
+          case 'D':
+            p.arc(0, 0, d, d, 0, p.PI, p.PIE);
+            break;
+          case 'R':
+            p.arc(0, 0, d, d, -p.HALF_PI, p.HALF_PI, p.PIE);
+            break;
+          case 'L':
+            p.arc(0, 0, d, d, p.HALF_PI, 3 * p.HALF_PI, p.PIE);
+            break;
+          case 'LU':
+            p.arc(0, 0, d, d, p.PI, 3 * p.HALF_PI, p.PIE);
+            break;
+          case 'RU':
+            p.arc(0, 0, d, d, 3 * p.HALF_PI, p.TWO_PI, p.PIE);
+            break;
+          case 'LD':
+            p.arc(0, 0, d, d, p.HALF_PI, p.PI, p.PIE);
+            break;
+          case 'RD':
+            p.arc(0, 0, d, d, 0, p.HALF_PI, p.PIE);
+            break;
+        }
       }
     }
 

--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -59,12 +59,6 @@ export default class SpatialUIController {
     const primary = '#B9B0B1';
     const secondary = '#89CFF0';
 
-    // -- Orb --------------------------------------------
-    this.orbController = new OrbController(this.p, {
-      center: { x: cx, y: cy },
-      diameter: 65,
-    });
-
     // -- GestureObject (15×15) --------------------------------------------
     class GestureObject {
       constructor(center, prefix, color) {
@@ -111,73 +105,79 @@ export default class SpatialUIController {
       }
     }
 
-    // -- WeightObject (visual only circle) ---------------------------------
-    class WeightObject {
-      constructor(center, diameter) {
-        this.center = center;
-        this.diameter = diameter;
-      }
-      draw() {
-        p.push();
-        p.translate(this.center.x, this.center.y);
-        p.noStroke();
-        p.fill(180, 130, 200, 180);
-        p.ellipse(0, 0, this.diameter);
-        p.pop();
-      }
-    }
+    // helper to build 3×3 grid of GestureObjects for a cluster
+    const buildCluster = (centerX, basePrefix) => {
+      return [
+        new GestureObject({ x: centerX, y: cy }, `${basePrefix}`, secondary),
+        new GestureObject({ x: centerX, y: cy - 100 }, `${basePrefix}U`, primary),
+        new GestureObject({ x: centerX, y: cy + 100 }, `${basePrefix}D`, primary),
+        new GestureObject(
+          {
+            x: centerX + this.hOffset - this.pairSpacing - this.extraGap / 2,
+            y: cy - 100,
+          },
+          `${basePrefix}UR`,
+          secondary
+        ),
+        new GestureObject(
+          {
+            x: centerX + this.hOffset - this.pairSpacing - this.extraGap / 2,
+            y: cy,
+          },
+          `${basePrefix}R`,
+          primary
+        ),
+        new GestureObject(
+          {
+            x: centerX + this.hOffset - this.pairSpacing - this.extraGap / 2,
+            y: cy + 100,
+          },
+          `${basePrefix}DR`,
+          secondary
+        ),
+        new GestureObject(
+          {
+            x: centerX - this.hOffset + this.pairSpacing + this.extraGap / 2,
+            y: cy - 100,
+          },
+          `${basePrefix}UL`,
+          secondary
+        ),
+        new GestureObject(
+          {
+            x: centerX - this.hOffset + this.pairSpacing + this.extraGap / 2,
+            y: cy,
+          },
+          `${basePrefix}L`,
+          primary
+        ),
+        new GestureObject(
+          {
+            x: centerX - this.hOffset + this.pairSpacing + this.extraGap / 2,
+            y: cy + 100,
+          },
+          `${basePrefix}DL`,
+          secondary
+        ),
+      ];
+    };
 
-    // instantiate gesture‐objects
-    this.allGestureObjects = [
-      new GestureObject({ x: cx, y: cy }, 'L', secondary),
-      new GestureObject({ x: cx, y: cy - 100 }, 'LU', primary),
-      new GestureObject({ x: cx, y: cy + 100 }, 'LD', primary),
-      new GestureObject(
-        {
-          x: cx + this.hOffset - this.pairSpacing - this.extraGap / 2,
-          y: cy - 100,
-        },
-        'LUR',
-        secondary
-      ),
-      new GestureObject(
-        { x: cx + this.hOffset - this.pairSpacing - this.extraGap / 2, y: cy },
-        'LR',
-        primary
-      ),
-      new GestureObject(
-        {
-          x: cx + this.hOffset - this.pairSpacing - this.extraGap / 2,
-          y: cy + 100,
-        },
-        'LDR',
-        secondary
-      ),
-      new GestureObject(
-        {
-          x: cx - this.hOffset + this.pairSpacing + this.extraGap / 2,
-          y: cy - 100,
-        },
-        'LUL',
-        secondary
-      ),
-      new GestureObject(
-        { x: cx - this.hOffset + this.pairSpacing + this.extraGap / 2, y: cy },
-        'LL',
-        primary
-      ),
-      new GestureObject(
-        {
-          x: cx - this.hOffset + this.pairSpacing + this.extraGap / 2,
-          y: cy + 100,
-        },
-        'LDL',
-        secondary
-      ),
-    ];
+    const spacing = this.hOffset * 2 + this.extraGap;
+    const leftCluster = buildCluster(cx - spacing / 2, 'L');
+    const rightCluster = buildCluster(cx + spacing / 2, 'R');
+    this.allGestureObjects = [...leftCluster, ...rightCluster];
 
-    // instantiate the central weight‐object visual
-    this.weightObject = new WeightObject({ x: cx, y: cy }, 65);
+    // -- Orb --------------------------------------------
+    this.orbControllers = {
+      L: new OrbController(this.p, {
+        center: { x: cx - spacing / 2, y: cy },
+        diameter: 65,
+      }),
+      R: new OrbController(this.p, {
+        center: { x: cx + spacing / 2, y: cy },
+        diameter: 65,
+      }),
+    };
 
     // -- integrate weight‐object BUTTON grid (40×40) -----------------------
     this.weightObjectButtons = {};
@@ -207,6 +207,15 @@ export default class SpatialUIController {
       'W.L.LD',
       'W.L.D',
       'W.L.RD',
+      'W.R.LU',
+      'W.R.U',
+      'W.R.RU',
+      'W.R.L',
+      'W.R',
+      'W.R.R',
+      'W.R.LD',
+      'W.R.D',
+      'W.R.RD',
     ];
     weightNames.forEach((name) => {
       const btn = p.createButton('');
@@ -215,7 +224,7 @@ export default class SpatialUIController {
       btn.style('border', '1px solid #800080');
       btn.style('border-radius', '5px');
       btn.style('font-size', '8px');
-      btn.html(name.replace('W.L.', ''));
+      btn.html(name.replace(/^W\.[LR]\./, ''));
       btn.parent(this.weightObjectButtonContainer);
       btn.mousePressed(() => {}); // wired later
       this.weightObjectButtons[name] = btn;
@@ -234,12 +243,14 @@ export default class SpatialUIController {
     });
     this.dotController.loadSequences([
       ['L', 'L.U', 'L.D', 'L.L', 'L.R'],
+      ['R', 'R.U', 'R.D', 'R.L', 'R.R'],
     ]);
   }
 
   render(dt) {
-    // 1) draw the static weight‐halo
-    this.orbController.draw();
+    // 1) draw the static weight‐halos
+    this.orbControllers.L.draw();
+    this.orbControllers.R.draw();
 
     // 1.5) draw context markers (behind the dot)
     if (this.showContextMarkers) {
@@ -247,8 +258,8 @@ export default class SpatialUIController {
       this.p.noStroke();
       this.p.fill(180, 130, 200, 180);
       this.allGestureObjects
-        // filter out the center marker (prefix 'L')
-        .filter((go) => go.prefix !== 'L')
+        // filter out the center markers (prefix 'L' and 'R')
+        .filter((go) => go.prefix !== 'L' && go.prefix !== 'R')
         .forEach((go) => {
           const { x, y } = go.center;
           this.p.ellipse(x, y, 45, 45);

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -109,16 +109,20 @@ export default class SystemUIController {
       this.textFieldCtrl.highlight(this._beatCount % maxCols);
     });
 
-    // advance dots/orb on subdivision
+    // advance dots/orbs on subdivision
     this.timer.on('subdivision', () => {
       if (!this.systemRunning) return;
       this.spatialUIController.dotController.advance();
       const len = this.weightSequence.length;
       if (len > 0) {
         const token = this.weightSequence[this.weightIndex];
-        const suffix = token.includes('.') ? token.split('.')[1] : '';
-        const section = suffix ? `W.L.${suffix}` : 'W.L';
-        this.spatialUIController.orbController.setHighlight(section);
+        const parts = token.split('.');
+        const side = parts[1] || 'L';
+        const dir = parts[2];
+        const section = dir ? `W.${side}.${dir}` : `W.${side}`;
+        const other = side === 'L' ? 'R' : 'L';
+        this.spatialUIController.orbControllers[side].setHighlight(section);
+        this.spatialUIController.orbControllers[other].clearHighlight();
         this.weightIndex = (this.weightIndex + 1) % len;
       }
     });
@@ -156,9 +160,13 @@ export default class SystemUIController {
     this.weightSequence = this.textFieldCtrl.getWeightValues();
     if (this.weightSequence.length > 0) {
       const first = this.weightSequence[0];
-      const suffix = first.includes('.') ? first.split('.')[1] : '';
-      const section = suffix ? `W.L.${suffix}` : 'W.L';
-      this.spatialUIController.orbController.setHighlight(section);
+      const parts = first.split('.');
+      const side = parts[1] || 'L';
+      const dir = parts[2];
+      const section = dir ? `W.${side}.${dir}` : `W.${side}`;
+      const other = side === 'L' ? 'R' : 'L';
+      this.spatialUIController.orbControllers[side].setHighlight(section);
+      this.spatialUIController.orbControllers[other].clearHighlight();
     }
     this.weightIndex = this.weightSequence.length > 1 ? 1 : 0;
 
@@ -172,7 +180,8 @@ export default class SystemUIController {
     this.timer.stop();
     this.textFieldCtrl.clearHighlights();
     this.spatialUIController.dotController.stop();
-    this.spatialUIController.orbController.clearHighlight();
+    this.spatialUIController.orbControllers.L.clearHighlight();
+    this.spatialUIController.orbControllers.R.clearHighlight();
     this.spatialUIController.showContextMarkersOff();
     this.weightIndex = 0;
   }


### PR DESCRIPTION
## Summary
- duplicate gesture clusters with new right-side set and dual orbs
- route weight tokens to L/R orb controllers and support W.R.* highlights
- mirror default sequences and fixtures for right-side gestures

## Testing
- `npm test` *(fails: Missing script "test" as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a7622558b48332afdc86519cbbbe6d