### PR TITLE
Add controls to toggle weight buttons

### DIFF
--- a/src/ui/buttonPanelController.js
+++ b/src/ui/buttonPanelController.js
@@ -65,6 +65,7 @@ export default class ButtonPanelController {
     makeBtn('startStop', 'Go', 60);
     makeBtn('togglePopUp', 'Pop Up Mode: Off', 100);
     makeBtn('toggleDuration', 'Duration: 8', 80);
+    makeBtn('toggleWeights', 'Weights: Off', 100);
     makeBtn('copyState', 'Copy State', 80);
     makeBtn('clearWeight', 'Clear Weight', 80);
     makeBtn('clearGesture', 'Clear Gesture', 80);
@@ -90,5 +91,9 @@ export default class ButtonPanelController {
   }
   updateDurationLabel(text) {
     this.buttons.toggleDuration.html(text);
+  }
+
+  updateWeightsLabel(text) {
+    this.buttons.toggleWeights.html(text);
   }
 }

--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -196,6 +196,8 @@ export default class SpatialUIController {
     }).forEach(([prop, val]) => {
       this.weightObjectButtonContainer.style(prop, val);
     });
+    // hidden by default; toggled via show/hideWeightButtons
+    this.weightObjectButtonContainer.style('visibility', 'hidden');
 
     const weightNames = [
       'W.L.LU',
@@ -292,6 +294,16 @@ export default class SpatialUIController {
         btn.style('visibility', 'visible')
       );
     });
+  }
+
+  /** Hide the 40×40 weight buttons */
+  hideWeightButtons() {
+    this.weightObjectButtonContainer.style('visibility', 'hidden');
+  }
+
+  /** Show the 40×40 weight buttons */
+  showWeightButtons() {
+    this.weightObjectButtonContainer.style('visibility', 'visible');
   }
 
   /** Turn context-marker circles on */

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -24,6 +24,7 @@ export default class SystemUIController {
     this.tempo = 60;
     this.duration = 8;
     this.popUpMode = false;
+    this.weightsVisible = false;
     this.systemRunning = false;
     this._activeDot = 0; // currently selected gesture row
 
@@ -81,6 +82,17 @@ export default class SystemUIController {
         this.timer.setDuration(this.duration);
         this.textFieldCtrl.updateLabels(this.timerMode, this.duration);
         this.buttonPanel.updateDurationLabel(`Duration: ${this.duration}`);
+      },
+      toggleWeights: () => {
+        this.weightsVisible = !this.weightsVisible;
+        if (this.weightsVisible) {
+          this.spatialUIController.showWeightButtons();
+        } else {
+          this.spatialUIController.hideWeightButtons();
+        }
+        this.buttonPanel.updateWeightsLabel(
+          `Weights: ${this.weightsVisible ? 'On' : 'Off'}`
+        );
       },
       copyState: () => this.copyState(),
       clearWeight: () => {


### PR DESCRIPTION
## Summary
- Hide weight object buttons by default and provide show/hide helpers.
- Add a button panel toggle to reveal or hide weight controls.
- Wire system controller to manage weight button visibility state.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3592a5ad083328da0168bf0472849