### PR TITLE
Add draggable glyph and selection bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -5,9 +5,12 @@
     <base href="/" />
     <meta charset="UTF-8" />
     <title>Double Weight</title>
-   
+    <link rel="stylesheet" href="/styles.css" />
     <!-- Only your module—p5 comes in via imports -->
     <script type="module" src="/src/main.js"></script>
   </head>
-  <body></body>
+  <body>
+    <div id="selection-bar"></div>
+    <div id="glyph" draggable="true"></div>
+  </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import SequenceManager from './managers/sequenceManager.js';
 import SystemUIController from './ui/systemUIController.js';
 import CanvasRenderer from './render/canvasRenderer.js';
 import SpatialUIController from './ui/spatialUIController.js';
+import GlyphController from './ui/glyphController.js';
 
 
 const timer = new TimerManager();
@@ -30,6 +31,7 @@ new p5((p) => {
       canvasRenderer: canvas,
       spatialUIController: spatialUI,
     });
+    new GlyphController();
 
     // ─── OPTIONAL SPATIALUI CALLBACKS ─────────────────────────────────────────
     spatialUI.setGestureCallback((name) => {

--- a/src/ui/buttonPanelController.js
+++ b/src/ui/buttonPanelController.js
@@ -33,6 +33,8 @@ export default class ButtonPanelController {
         .style('font-size', '10px')
         .parent(this.container)
         .mousePressed(() => this.handlers[key]?.());
+      btn.addClass('gesture-btn');
+      btn.attribute('data-name', label);
       this.buttons[key] = btn;
     };
 

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -1,0 +1,32 @@
+export default class GlyphController {
+  constructor() {
+    this.glyph = document.getElementById('glyph');
+    this.bar = document.getElementById('selection-bar');
+    if (!this.glyph || !this.bar) return;
+    this._setupGlyph();
+    this._setupDropTargets();
+  }
+
+  _setupGlyph() {
+    this.glyph.addEventListener('dragstart', (e) => {
+      e.dataTransfer.setData('text/plain', 'glyph');
+    });
+  }
+
+  _setupDropTargets() {
+    const buttons = document.querySelectorAll('.gesture-btn');
+    buttons.forEach((btn) => {
+      btn.addEventListener('dragover', (e) => e.preventDefault());
+      btn.addEventListener('drop', (e) => {
+        e.preventDefault();
+        btn.style.backgroundColor = '#3fc009';
+        const name = btn.dataset.name || btn.textContent.trim();
+        const field = document.createElement('input');
+        field.type = 'text';
+        field.value = name;
+        field.readOnly = true;
+        this.bar.appendChild(field);
+      });
+    });
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -44,3 +44,26 @@ h1 {
   font-weight: bold;
   font-size: 1.5rem;
 }
+
+#glyph {
+  position: fixed;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: #3fc009;
+  cursor: grab;
+  z-index: 1000;
+}
+
+#selection-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  gap: 6px;
+  padding: 6px;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- add fixed #3fc009 glyph and top selection bar for dropped gesture buttons
- mark buttons as drag targets and handle drops to highlight and list button names
- ignore node_modules directory

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b3ed1ad4fc8332bd2598e9b10a0553