### PR TITLE
Resize glyph to match gesture button size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -49,10 +49,9 @@ h1 {
   position: fixed;
   right: 20px;
   top: 50%;
-  transform: translateY(-50%);
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  transform: translateY(-50%) rotate(45deg);
+  width: 15px;
+  height: 15px;
   background: #3fc009;
   cursor: grab;
   z-index: 1000;


### PR DESCRIPTION
## Summary
- Resize draggable glyph to 15×15 and rotate 45° so it matches individual gesture buttons.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3f1636f648332ae02cf7ae5a456aa