### PR TITLE
Add gesture button metadata

### DIFF
--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -73,6 +73,8 @@ export default class SpatialUIController {
           btn.style('background-color', color);
           btn.style('border', 'none');
           btn.style('transform', 'rotate(45deg)');
+          btn.addClass('gesture-btn');
+          btn.attribute('data-name', name);
           btn.mousePressed(() => {}); // wired later
           this.buttons[name] = btn;
         });
@@ -227,6 +229,8 @@ export default class SpatialUIController {
       btn.style('border-radius', '5px');
       btn.style('font-size', '8px');
       btn.html(name.replace(/^W\.[LR]\./, ''));
+      btn.addClass('gesture-btn');
+      btn.attribute('data-name', name.replace(/^W\.[LR]\./, ''));
       btn.parent(this.weightObjectButtonContainer);
       btn.mousePressed(() => {}); // wired later
       this.weightObjectButtons[name] = btn;


### PR DESCRIPTION
## Summary
- Tag each gesture button as a drop target with class `gesture-btn` and unique `data-name` attribute
- Similarly tag weight buttons to support drag-and-drop label display

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3f6d4f3bc8332a5ab3a4adbe3869a