### PR TITLE
Style glyph inputs and adjust selection bar positioning

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -32,6 +32,9 @@ export default class GlyphController {
         field.type = 'text';
         field.value = name;
         field.readOnly = true;
+        field.style.width = '56px';
+        field.style.fontSize = '8px';
+        field.style.height = '20px';
         this.bar.appendChild(field);
       });
     });

--- a/styles.css
+++ b/styles.css
@@ -60,7 +60,7 @@ h1 {
 
 #selection-bar {
   position: fixed;
-  top: 0;
+  top: 100px;
   left: 0;
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## Summary
- Style gesture drop target fields with fixed width, font size, and height.
- Move the selection bar down to leave space for gestures.

## Testing
- `timeout 5 npm start`


------
https://chatgpt.com/codex/tasks/task_e_68b45bdce45c8332aeebc327995235f9