### PR TITLE
Add flashing timeline display

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import SystemUIController from './ui/systemUIController.js';
 import CanvasRenderer from './render/canvasRenderer.js';
 import SpatialUIController from './ui/spatialUIController.js';
 import GlyphController from './ui/glyphController.js';
+import TimelineDisplay from './ui/timelineDisplay.js';
 
 
 const timer = new TimerManager();
@@ -13,7 +14,7 @@ const sequences = new SequenceManager();
 
 
 new p5((p) => {
-  let systemUI, spatialUI, canvas;
+  let systemUI, spatialUI, canvas, timeline;
 
   p.preload = () => {
     sequences.preload(p);
@@ -32,6 +33,8 @@ new p5((p) => {
       spatialUIController: spatialUI,
     });
     new GlyphController();
+    timeline = new TimelineDisplay(p);
+    timeline.build();
 
     // ─── OPTIONAL SPATIALUI CALLBACKS ─────────────────────────────────────────
     spatialUI.setGestureCallback((name) => {

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -1,0 +1,40 @@
+// src/ui/timelineDisplay.js
+
+export default class TimelineDisplay {
+  constructor(p) {
+    this.p = p;
+    this.container = null;
+  }
+
+  build() {
+    this.container = this.p
+      .createDiv('')
+      .id('timeline-display');
+
+    const center = 60;
+    const radius = 40;
+    const diag = radius / Math.sqrt(2);
+
+    const dots = [
+      { name: 'C',  x: center,        y: center },
+      { name: 'R',  x: center + radius, y: center },
+      { name: 'L',  x: center - radius, y: center },
+      { name: 'U',  x: center,        y: center - radius },
+      { name: 'D',  x: center,        y: center + radius },
+      { name: 'UR', x: center + diag, y: center - diag },
+      { name: 'UL', x: center - diag, y: center - diag },
+      { name: 'DR', x: center + diag, y: center + diag },
+      { name: 'DL', x: center - diag, y: center + diag },
+    ];
+
+    let svg = `<svg viewBox="0 0 ${center * 2} ${center * 2}">`;
+    svg += `<circle class="outer" cx="${center}" cy="${center}" r="${radius}" />`;
+    dots.forEach((d) => {
+      svg += `<circle class="dot" cx="${d.x}" cy="${d.y}" r="6"></circle>`;
+      svg += `<text x="${d.x}" y="${d.y}" class="label">${d.name}</text>`;
+    });
+    svg += `</svg>`;
+
+    this.container.html(svg);
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -67,3 +67,47 @@ h1 {
   padding: 6px;
   z-index: 1000;
 }
+
+#timeline-display {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 120px;
+  height: 120px;
+  z-index: 1000;
+}
+
+#timeline-display svg {
+  width: 100%;
+  height: 100%;
+}
+
+#timeline-display .outer {
+  stroke: #ccc;
+  fill: none;
+  stroke-width: 1;
+  animation: timelineFlashStroke 1s infinite;
+}
+
+#timeline-display .dot {
+  fill: #ccc;
+  animation: timelineFlashFill 1s infinite;
+}
+
+#timeline-display text {
+  font-size: 10px;
+  fill: #000;
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
+
+@keyframes timelineFlashStroke {
+  0%, 100% { stroke: #ccc; }
+  50% { stroke: #ff0000; }
+}
+
+@keyframes timelineFlashFill {
+  0%, 100% { fill: #ccc; }
+  50% { fill: #ff0000; }
+}


### PR DESCRIPTION
## Summary
- Add SVG-based 9-position timeline display at page top with flashing dots
- Import and build timeline display in main setup
- Style timeline display and animations in CSS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b45e9152a08332b2d0911e2b2e12a8