### PR TITLE
Redesign timeline display without flashing labels

### DIFF
--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -10,28 +10,25 @@ export default class TimelineDisplay {
     this.container = this.p
       .createDiv('')
       .id('timeline-display');
-
     const center = 60;
-    const radius = 40;
-    const diag = radius / Math.sqrt(2);
+    const spacing = 40;
 
     const dots = [
-      { name: 'C',  x: center,        y: center },
-      { name: 'R',  x: center + radius, y: center },
-      { name: 'L',  x: center - radius, y: center },
-      { name: 'U',  x: center,        y: center - radius },
-      { name: 'D',  x: center,        y: center + radius },
-      { name: 'UR', x: center + diag, y: center - diag },
-      { name: 'UL', x: center - diag, y: center - diag },
-      { name: 'DR', x: center + diag, y: center + diag },
-      { name: 'DL', x: center - diag, y: center + diag },
+      { x: center - spacing, y: center - spacing },
+      { x: center, y: center - spacing },
+      { x: center + spacing, y: center - spacing },
+      { x: center - spacing, y: center },
+      { x: center, y: center },
+      { x: center + spacing, y: center },
+      { x: center - spacing, y: center + spacing },
+      { x: center, y: center + spacing },
+      { x: center + spacing, y: center + spacing },
     ];
 
     let svg = `<svg viewBox="0 0 ${center * 2} ${center * 2}">`;
-    svg += `<circle class="outer" cx="${center}" cy="${center}" r="${radius}" />`;
+    svg += `<circle class="outer" cx="${center}" cy="${center}" r="${spacing}" />`;
     dots.forEach((d) => {
       svg += `<circle class="dot" cx="${d.x}" cy="${d.y}" r="6"></circle>`;
-      svg += `<text x="${d.x}" y="${d.y}" class="label">${d.name}</text>`;
     });
     svg += `</svg>`;
 

--- a/styles.css
+++ b/styles.css
@@ -87,27 +87,8 @@ h1 {
   stroke: #ccc;
   fill: none;
   stroke-width: 1;
-  animation: timelineFlashStroke 1s infinite;
 }
 
 #timeline-display .dot {
   fill: #ccc;
-  animation: timelineFlashFill 1s infinite;
-}
-
-#timeline-display text {
-  font-size: 10px;
-  fill: #000;
-  text-anchor: middle;
-  dominant-baseline: middle;
-}
-
-@keyframes timelineFlashStroke {
-  0%, 100% { stroke: #ccc; }
-  50% { stroke: #ff0000; }
-}
-
-@keyframes timelineFlashFill {
-  0%, 100% { fill: #ccc; }
-  50% { fill: #ff0000; }
 }


### PR DESCRIPTION
## Summary
- Remove flashing animation and labels from timeline display
- Arrange timeline dots in a 3×3 grid and draw an outer circle through U/D/R/L

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b46093c32c8332ad9834cc0b728b3f