### PR TITLE
Support multiple timelines with flexible layout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ const sequences = new SequenceManager();
 
 
 new p5((p) => {
-  let systemUI, spatialUI, canvas, timeline;
+  let systemUI, spatialUI, canvas, timeline1, timeline2;
 
   p.preload = () => {
     sequences.preload(p);
@@ -33,8 +33,14 @@ new p5((p) => {
       spatialUIController: spatialUI,
     });
     new GlyphController();
-    timeline = new TimelineDisplay(p);
-    timeline.build();
+    const wrapper = p.createDiv('').id('timeline-wrapper');
+    timeline1 = new TimelineDisplay(p, 'timeline-display-1');
+    timeline1.build();
+    timeline1.container.parent(wrapper);
+
+    timeline2 = new TimelineDisplay(p, 'timeline-display-2');
+    timeline2.build();
+    timeline2.container.parent(wrapper);
 
     // ─── OPTIONAL SPATIALUI CALLBACKS ─────────────────────────────────────────
     spatialUI.setGestureCallback((name) => {

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -1,15 +1,17 @@
 // src/ui/timelineDisplay.js
 
 export default class TimelineDisplay {
-  constructor(p) {
+  constructor(p, id) {
     this.p = p;
+    this.id = id;
     this.container = null;
   }
 
   build() {
     this.container = this.p
       .createDiv('')
-      .id('timeline-display');
+      .id(this.id)
+      .class('timeline-display');
     const center = 60;
     const spacing = 40;
 

--- a/styles.css
+++ b/styles.css
@@ -68,27 +68,33 @@ h1 {
   z-index: 1000;
 }
 
-#timeline-display {
+#timeline-wrapper {
   position: fixed;
   top: 10px;
   left: 50%;
   transform: translateX(-50%);
-  width: 120px;
-  height: 120px;
+  display: flex;
+  gap: 20px;
+  justify-content: center;
   z-index: 1000;
 }
 
-#timeline-display svg {
+.timeline-display {
+  width: 120px;
+  height: 120px;
+}
+
+.timeline-display svg {
   width: 100%;
   height: 100%;
 }
 
-#timeline-display .outer {
+.timeline-display .outer {
   stroke: #ccc;
   fill: none;
   stroke-width: 1;
 }
 
-#timeline-display .dot {
+.timeline-display .dot {
   fill: #ccc;
 }


### PR DESCRIPTION
## Summary
- allow `TimelineDisplay` to accept custom element IDs and use a shared CSS class
- show two timelines within a flex-based `timeline-wrapper`
- replace `#timeline-display` styling with `.timeline-display` and add styles for `#timeline-wrapper`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b464e2a54c833296b0cc59f06f767d