### PR TITLE
Add green glyph markers to timeline displays

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,6 @@ new p5((p) => {
       canvasRenderer: canvas,
       spatialUIController: spatialUI,
     });
-    new GlyphController();
     const wrapper = p.createDiv('').id('timeline-wrapper');
     timeline1 = new TimelineDisplay(p, 'timeline-display-1');
     timeline1.build();
@@ -41,6 +40,8 @@ new p5((p) => {
     timeline2 = new TimelineDisplay(p, 'timeline-display-2');
     timeline2.build();
     timeline2.container.parent(wrapper);
+
+    new GlyphController({ timelineDisplays: { L: timeline1, R: timeline2 } });
 
     // ─── OPTIONAL SPATIALUI CALLBACKS ─────────────────────────────────────────
     spatialUI.setGestureCallback((name) => {

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -1,7 +1,8 @@
 export default class GlyphController {
-  constructor() {
+  constructor({ timelineDisplays = {} } = {}) {
     this.glyph = document.getElementById('glyph');
     this.bar = document.getElementById('selection-bar');
+    this.timelineDisplays = timelineDisplays;
     if (!this.glyph || !this.bar) return;
     this._setupGlyph();
     this._setupDropTargets();
@@ -36,7 +37,18 @@ export default class GlyphController {
         field.style.fontSize = '8px';
         field.style.height = '20px';
         this.bar.appendChild(field);
+        this._markDisplay(name);
       });
     });
+  }
+
+  _markDisplay(token) {
+    const parts = token.split('.');
+    const side = parts[0];
+    const pos = parts[1] || 'C';
+    const display = this.timelineDisplays[side];
+    if (display && pos) {
+      display.addMarker(pos);
+    }
   }
 }

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -5,6 +5,10 @@ export default class TimelineDisplay {
     this.p = p;
     this.id = id;
     this.container = null;
+    this.svg = null;
+    this.center = 60;
+    this.spacing = 40;
+    this.dotPositions = {};
   }
 
   build() {
@@ -12,20 +16,25 @@ export default class TimelineDisplay {
       .createDiv('')
       .id(this.id)
       .class('timeline-display');
-    const center = 60;
-    const spacing = 40;
+    const center = this.center;
+    const spacing = this.spacing;
 
     const dots = [
-      { x: center - spacing, y: center - spacing },
-      { x: center, y: center - spacing },
-      { x: center + spacing, y: center - spacing },
-      { x: center - spacing, y: center },
-      { x: center, y: center },
-      { x: center + spacing, y: center },
-      { x: center - spacing, y: center + spacing },
-      { x: center, y: center + spacing },
-      { x: center + spacing, y: center + spacing },
+      { name: 'UL', x: center - spacing, y: center - spacing },
+      { name: 'U', x: center, y: center - spacing },
+      { name: 'UR', x: center + spacing, y: center - spacing },
+      { name: 'L', x: center - spacing, y: center },
+      { name: 'C', x: center, y: center },
+      { name: 'R', x: center + spacing, y: center },
+      { name: 'DL', x: center - spacing, y: center + spacing },
+      { name: 'D', x: center, y: center + spacing },
+      { name: 'DR', x: center + spacing, y: center + spacing },
     ];
+
+    // build map for later lookup
+    dots.forEach((d) => {
+      this.dotPositions[d.name] = { x: d.x, y: d.y };
+    });
 
     let svg = `<svg viewBox="0 0 ${center * 2} ${center * 2}">`;
     svg += `<circle class="outer" cx="${center}" cy="${center}" r="${spacing}" />`;
@@ -35,5 +44,30 @@ export default class TimelineDisplay {
     svg += `</svg>`;
 
     this.container.html(svg);
+    this.svg = this.container.elt.querySelector('svg');
+  }
+
+  /**
+   * Add a green marker outside the dot matching the given position.
+   * @param {string} pos one of 'UL','U','UR','L','C','R','DL','D','DR'
+   */
+  addMarker(pos) {
+    if (!this.svg || !this.dotPositions[pos]) return;
+
+    const base = this.dotPositions[pos];
+    let { x, y } = base;
+
+    // for non-center positions, offset outward slightly
+    if (pos !== 'C') {
+      const dx = x - this.center;
+      const dy = y - this.center;
+      const mag = Math.sqrt(dx * dx + dy * dy) || 1;
+      const offset = 10;
+      x = this.center + (dx / mag) * (mag + offset);
+      y = this.center + (dy / mag) * (mag + offset);
+    }
+
+    const circle = `<circle class="glyph-marker" cx="${x}" cy="${y}" r="6"></circle>`;
+    this.svg.insertAdjacentHTML('beforeend', circle);
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -98,3 +98,7 @@ h1 {
 .timeline-display .dot {
   fill: #ccc;
 }
+
+.timeline-display .glyph-marker {
+  fill: #3fc009;
+}


### PR DESCRIPTION
## Summary
- show timeline displays before glyph controller
- mark corresponding timeline display with green dot when glyph is dropped
- add API on timeline display to render markers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b467e669108332898b2adb2747656f