### PR TITLE
Increase glyph marker offset to prevent overlap

### DIFF
--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -62,7 +62,7 @@ export default class TimelineDisplay {
       const dx = x - this.center;
       const dy = y - this.center;
       const mag = Math.sqrt(dx * dx + dy * dy) || 1;
-      const offset = 10;
+      const offset = 16;
       x = this.center + (dx / mag) * (mag + offset);
       y = this.center + (dy / mag) * (mag + offset);
     }


### PR DESCRIPTION
## Summary
- push glyph markers further from timeline dots to avoid overlapping

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4699245fc8332a15db51dfd3df0c1