### PR TITLE
Support nested timeline marker positions

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -45,10 +45,10 @@ export default class GlyphController {
   _markDisplay(token) {
     const parts = token.split('.');
     const side = parts[0];
-    const pos = parts[1] || 'C';
+    const posPath = parts.slice(1).join('.') || 'C';
     const display = this.timelineDisplays[side];
-    if (display && pos) {
-      display.addMarker(pos);
+    if (display) {
+      display.addMarker(posPath);
     }
   }
 }

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -8,7 +8,6 @@ export default class TimelineDisplay {
     this.svg = null;
     this.center = 60;
     this.spacing = 40;
-    this.dotPositions = {};
   }
 
   build() {
@@ -31,11 +30,6 @@ export default class TimelineDisplay {
       { name: 'DR', x: center + spacing, y: center + spacing },
     ];
 
-    // build map for later lookup
-    dots.forEach((d) => {
-      this.dotPositions[d.name] = { x: d.x, y: d.y };
-    });
-
     let svg = `<svg viewBox="0 0 ${center * 2} ${center * 2}">`;
     svg += `<circle class="outer" cx="${center}" cy="${center}" r="${spacing}" />`;
     dots.forEach((d) => {
@@ -47,24 +41,76 @@ export default class TimelineDisplay {
     this.svg = this.container.elt.querySelector('svg');
   }
 
-  /**
-   * Add a green marker outside the dot matching the given position.
-   * @param {string} pos one of 'UL','U','UR','L','C','R','DL','D','DR'
-   */
-  addMarker(pos) {
-    if (!this.svg || !this.dotPositions[pos]) return;
+  getPosition(path) {
+    let x = this.center;
+    let y = this.center;
+    let spacing = this.spacing;
+    let parentX = x;
+    let parentY = y;
+    const segments = path ? path.split('.') : [];
+    segments.forEach((seg) => {
+      parentX = x;
+      parentY = y;
+      switch (seg) {
+        case 'UL':
+          x -= spacing;
+          y -= spacing;
+          break;
+        case 'U':
+          y -= spacing;
+          break;
+        case 'UR':
+          x += spacing;
+          y -= spacing;
+          break;
+        case 'L':
+          x -= spacing;
+          break;
+        case 'C':
+          break;
+        case 'R':
+          x += spacing;
+          break;
+        case 'DL':
+          x -= spacing;
+          y += spacing;
+          break;
+        case 'D':
+          y += spacing;
+          break;
+        case 'DR':
+          x += spacing;
+          y += spacing;
+          break;
+        default:
+          break;
+      }
+      spacing /= 2;
+    });
+    return { x, y, parentX, parentY };
+  }
 
-    const base = this.dotPositions[pos];
-    let { x, y } = base;
+  /**
+   * Add a green marker outside the dot matching the given path.
+   * @param {string} path dotted path such as 'UR.DR'
+   */
+  addMarker(path) {
+    if (!this.svg) return;
+
+    const { x: baseX, y: baseY, parentX, parentY } = this.getPosition(path);
+    let x = baseX;
+    let y = baseY;
 
     // for non-center positions, offset outward slightly
-    if (pos !== 'C') {
-      const dx = x - this.center;
-      const dy = y - this.center;
+    const segments = path.split('.');
+    const last = segments[segments.length - 1] || 'C';
+    if (last !== 'C') {
+      const dx = baseX - parentX;
+      const dy = baseY - parentY;
       const mag = Math.sqrt(dx * dx + dy * dy) || 1;
       const offset = 16;
-      x = this.center + (dx / mag) * (mag + offset);
-      y = this.center + (dy / mag) * (mag + offset);
+      x = baseX + (dx / mag) * offset;
+      y = baseY + (dy / mag) * offset;
     }
 
     const circle = `<circle class="glyph-marker" cx="${x}" cy="${y}" r="6"></circle>`;


### PR DESCRIPTION
## Summary
- Preserve full position paths from glyph drops when marking timeline displays
- Calculate marker coordinates hierarchically for nested grid positions
- Replace static dot map with dynamic `getPosition` helper in timeline display

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b46b8ae4d88332b0be35793ff7fe17