### PR TITLE
Track drop position in timeline markers

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -28,7 +28,15 @@ export default class GlyphController {
       btn.addEventListener('drop', (e) => {
         e.preventDefault();
         btn.style.backgroundColor = '#3fc009';
+
         const name = btn.dataset.name || btn.textContent.trim();
+
+        // Determine horizontal ratio of drop within the gesture grid
+        const container = btn.parentElement || document.body;
+        const rect = container.getBoundingClientRect();
+        let ratio = (e.clientX - rect.left) / rect.width;
+        ratio = Math.min(Math.max(ratio, 0), 1);
+
         const field = document.createElement('input');
         field.type = 'text';
         field.value = name;
@@ -37,18 +45,18 @@ export default class GlyphController {
         field.style.fontSize = '8px';
         field.style.height = '20px';
         this.bar.appendChild(field);
-        this._markDisplay(name);
+        this._markDisplay(name, ratio);
       });
     });
   }
 
-  _markDisplay(token) {
+  _markDisplay(token, ratio) {
     const parts = token.split('.');
     const side = parts[0];
     const posPath = parts.slice(1).join('.') || 'C';
     const display = this.timelineDisplays[side];
     if (display) {
-      display.addMarker(posPath);
+      display.addMarker(posPath, ratio);
     }
   }
 }

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -91,14 +91,16 @@ export default class TimelineDisplay {
   }
 
   /**
-   * Add a green marker outside the dot matching the given path.
+   * Add a green marker at the given path and horizontal ratio.
    * @param {string} path dotted path such as 'UR.DR'
+   * @param {number} ratio value from 0–1 indicating timeline position
    */
-  addMarker(path) {
+  addMarker(path, ratio = 0) {
     if (!this.svg) return;
 
     const { x: baseX, y: baseY, parentX, parentY } = this.getPosition(path);
-    let x = baseX;
+    const timelineX = ratio * (this.center * 2);
+    let x = timelineX;
     let y = baseY;
 
     // for non-center positions, offset outward slightly
@@ -109,11 +111,15 @@ export default class TimelineDisplay {
       const dy = baseY - parentY;
       const mag = Math.sqrt(dx * dx + dy * dy) || 1;
       const offset = 16;
-      x = baseX + (dx / mag) * offset;
+      x = timelineX + (dx / mag) * offset;
       y = baseY + (dy / mag) * offset;
     }
 
-    const circle = `<circle class="glyph-marker" cx="${x}" cy="${y}" r="6"></circle>`;
-    this.svg.insertAdjacentHTML('beforeend', circle);
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('class', 'glyph-marker');
+    circle.setAttribute('cx', x);
+    circle.setAttribute('cy', y);
+    circle.setAttribute('r', 6);
+    this.svg.appendChild(circle);
   }
 }


### PR DESCRIPTION
## Summary
- compute glyph drop position ratio and forward it to timeline displays
- accept a ratio in `TimelineDisplay.addMarker` and place markers horizontally using SVG DOM methods

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b46fb3f15c8332ae59272b8a70acc1