### PR TITLE
Fix nested marker alignment in timeline display

### DIFF
--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -76,7 +76,8 @@ export default class TimelineDisplay {
     const pos = this.getPosition(path);
     if (!pos) return;
 
-    const x = ratio * (this.center * 2) + (pos.x - this.center);
+    const baseX = pos.depth > 1 ? pos.parentX : pos.x;
+    const x = ratio * (this.center * 2) + (baseX - this.center);
     const y = pos.y;
 
     const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');


### PR DESCRIPTION
## Summary
- align markers for nested tokens by using parent x position as baseline

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b47ca30c388332ba4893831d0d8b31