### PR TITLE
feat: recenter canvas on window resize

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -59,4 +59,6 @@ new p5((p) => {
     spatialUI.render(p.deltaTime);
     systemUI.render(p.deltaTime);
   };
+
+  p.windowResized = () => canvas.recenter();
 });

--- a/src/render/canvasRenderer.js
+++ b/src/render/canvasRenderer.js
@@ -20,6 +20,11 @@ export default class CanvasRenderer {
     this.p.select('body').style('background-color', '#000');
   }
 
+  recenter() {
+    this.offsetX = (this.p.windowWidth - this.width) / 2;
+    this.canvas.position(this.offsetX, this.offsetY);
+  }
+
   clear() {
     this.p.clear();
     this.p.background(0);


### PR DESCRIPTION
## Summary
- add `recenter` method to CanvasRenderer to recompute horizontal offset and reposition canvas
- recenter canvas on `windowResized` so UI elements track canvas position

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b47e71ad948332864512598086d21a