### PR TITLE
Show sub-position markers for context gestures

### DIFF
--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -267,8 +267,10 @@ export default class SpatialUIController {
         // filter out the center markers (prefix 'L' and 'R')
         .filter((go) => go.prefix !== 'L' && go.prefix !== 'R')
         .forEach((go) => {
-          const { x, y } = go.center;
-          this.p.ellipse(x, y, 45, 45);
+          const points = Object.values(go.getPositions());
+          points.forEach((pt) => {
+            this.p.ellipse(pt.x, pt.y, 10, 10);
+          });
         });
       this.p.pop();
     }


### PR DESCRIPTION
## Summary
- Visualize all sub-positions for context gestures by drawing small circles for each `getPositions()` point instead of a single large marker.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b480d8dcac83328e7499e9b9f4ed86