### PR TITLE
Render sub-position markers in timeline display

### DIFF
--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -30,8 +30,7 @@ export default class TimelineDisplay {
       const token = path.join('.');
       if (depth > 0) {
         const cls = depth === 1 ? 'dot' : 'dot sub-dot';
-        const style = depth === 1 ? '' : ' style="opacity:0"';
-        svg += `<circle class="${cls}" cx="${x}" cy="${y}" r="6"${style}></circle>`;
+        svg += `<circle class="${cls}" cx="${x}" cy="${y}" r="6"></circle>`;
         this.positionMap[token] = { x, y, parentX: parent.x, parentY: parent.y, depth };
       }
       if (depth === 2) return;

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,10 @@ h1 {
   fill: #ccc;
 }
 
+.timeline-display .sub-dot {
+  fill: #eee;
+}
+
 .timeline-display .glyph-marker {
   fill: #3fc009;
 }


### PR DESCRIPTION
## Summary
- Render every generated timeline position without inline opacity
- Style sub-positions with a lighter fill for visibility

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b482bfaac883328a3277a6ddf91299