### PR TITLE
Outline timeline dots for glyph highlighting

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -96,11 +96,15 @@ h1 {
 }
 
 .timeline-display .dot {
-  fill: #ccc;
+  fill: none;
+  stroke: #ccc;
+  stroke-width: 1;
 }
 
 .timeline-display .sub-dot {
-  fill: #eee;
+  fill: none;
+  stroke: #eee;
+  stroke-width: 1;
 }
 
 .timeline-display .glyph-marker {


### PR DESCRIPTION
## Summary
- Outline timeline dots with stroke and no fill so markers highlight in green.
- Verify `addMarker` applies `glyph-marker` class to activate green fill.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b485d483948332aee900ae417be27f