### PR TITLE
Ensure timeline sub-dots start invisible

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -96,15 +96,12 @@ h1 {
 }
 
 .timeline-display .dot {
-  fill: none;
-  stroke: #ccc;
-  stroke-width: 1;
+  fill: #ccc;
 }
 
 .timeline-display .sub-dot {
   fill: none;
-  stroke: #eee;
-  stroke-width: 1;
+  stroke: none;
 }
 
 .timeline-display .glyph-marker {


### PR DESCRIPTION
## Summary
- Render primary timeline dots in grey by default
- Hide sub-dots until glyphs dropped, keep glyph-marker styling

## Testing
- `npm test` (fails: Missing script)
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68b4874ac35c83328eec0e2b7440bcf0