### PR TITLE
Increase sub-position spacing for timeline dots

### DIFF
--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -27,7 +27,7 @@ export default class TimelineDisplay {
     svg += `<circle class="outer" cx="${center}" cy="${center}" r="${spacing}" />`;
 
     const names = ['UL', 'U', 'UR', 'L', 'C', 'R', 'DL', 'D', 'DR'];
-    const subSpacing = 10;
+    const subSpacing = 15;
     const generate = (path, x, y, depth, parent) => {
       const token = path.join('.');
       if (depth > 0) {


### PR DESCRIPTION
## Summary
- Expand sub-position offset from 10px to 15px in the timeline display to space sub-position dots further from parent dots.

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b4884401888332bcd55699eb55cded