### PR TITLE
Adjust subposition circle radius in timeline display

### DIFF
--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -32,7 +32,8 @@ export default class TimelineDisplay {
       const token = path.join('.');
       if (depth > 0) {
         const cls = depth === 1 ? 'dot' : 'dot sub-dot';
-        svg += `<circle data-token="${token}" class="${cls}" cx="${x}" cy="${y}" r="6"></circle>`;
+        const radius = depth === 1 ? 6 : 3;
+        svg += `<circle data-token="${token}" class="${cls}" cx="${x}" cy="${y}" r="${radius}"></circle>`;
         this.positionMap[token] = { x, y, parentX: parent.x, parentY: parent.y, depth };
       }
       if (depth === 2) return;


### PR DESCRIPTION
## Summary
- Render second-level timeline nodes with a smaller radius so subpositions appear more distinct.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68b48a4fc0048332894f8f63c62735bf