### PR TITLE
Adjust text field UI position to avoid widget overlap

### DIFF
--- a/src/ui/textFieldController.js
+++ b/src/ui/textFieldController.js
@@ -13,7 +13,7 @@ export default class TextFieldController {
     this.container = p.createDiv()
       .style('position', 'fixed')
       // Move down to make room for a single gesture object plus padding
-      .style('top', '100px')
+      .style('top', 'calc(100px + 1.75 * 20px)')
       .style('left', '0')
       .style('width', '100%')
       .style('height', '105px')


### PR DESCRIPTION
## Summary
- Shift text field container down using CSS `calc` to clear display widgets.

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68b48cd1162483328bf93a002e66b7b3