### PR TITLE
Add second draggable glyph and update drag handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,13 @@
   </head>
   <body>
     <div id="selection-bar"></div>
-    <div id="glyph" draggable="true"></div>
+    <div id="glyph" class="glyph" draggable="true"></div>
+    <div id="glyph2" class="glyph" draggable="true">
+      <svg width="40" height="40">
+        <line x1="6" y1="34" x2="34" y2="6" stroke="#3fc009" stroke-width="2"/>
+        <circle cx="6" cy="34" r="7" fill="#3fc009"/>
+        <circle cx="34" cy="6" r="7" fill="#3fc009"/>
+      </svg>
+    </div>
   </body>
 </html>

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -1,23 +1,26 @@
 export default class GlyphController {
   constructor({ timelineDisplays = {} } = {}) {
-    this.glyph = document.getElementById('glyph');
+    this.glyphs = document.querySelectorAll('.glyph');
     this.bar = document.getElementById('selection-bar');
     this.timelineDisplays = timelineDisplays;
-    if (!this.glyph || !this.bar) return;
-    this._setupGlyph();
+    if (!this.glyphs.length || !this.bar) return;
+    this._setupGlyphs();
     this._setupDropTargets();
   }
 
-  _setupGlyph() {
-    this.glyph.addEventListener('dragstart', (e) => {
-      const clone = this.glyph.cloneNode(true);
-      clone.style.position = 'absolute';
-      clone.style.top = '-9999px';
-      clone.style.right = '-9999px';
-      document.body.appendChild(clone);
-      e.dataTransfer.setDragImage(clone, 7.5, 7.5);
-      e.dataTransfer.setData('text/plain', 'glyph');
-      setTimeout(() => document.body.removeChild(clone), 0);
+  _setupGlyphs() {
+    this.glyphs.forEach((glyph) => {
+      glyph.addEventListener('dragstart', (e) => {
+        const clone = glyph.cloneNode(true);
+        clone.style.position = 'absolute';
+        clone.style.top = '-9999px';
+        clone.style.right = '-9999px';
+        document.body.appendChild(clone);
+        const rect = glyph.getBoundingClientRect();
+        e.dataTransfer.setDragImage(clone, rect.width / 2, rect.height / 2);
+        e.dataTransfer.setData('text/plain', 'glyph');
+        setTimeout(() => document.body.removeChild(clone), 0);
+      });
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -45,18 +45,29 @@ h1 {
   font-size: 1.5rem;
 }
 
-#glyph {
-  position: fixed;
-  right: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 15px;
-  height: 15px;
-  background: #3fc009;
-  border-radius: 50%;
-  cursor: grab;
-  z-index: 1000;
-}
+  .glyph {
+    cursor: grab;
+    position: fixed;
+    z-index: 1000;
+  }
+
+  #glyph {
+    right: 20px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 15px;
+    height: 15px;
+    background: #3fc009;
+    border-radius: 50%;
+  }
+
+  #glyph2 {
+    right: 50px; /* adjust position as needed */
+    top: 50%;
+    transform: translateY(-50%);
+    width: 40px;
+    height: 40px;
+  }
 
 #selection-bar {
   position: fixed;


### PR DESCRIPTION
## Summary
- Add a second draggable SVG glyph element and assign shared glyph styling
- Position new glyph and extract common glyph styles into `.glyph`
- Update glyph controller to support dragging multiple glyph instances

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1937480833293f7ee789e97d566