### PR TITLE
Split glyph2 into separate draggable circles

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,14 @@
   <body>
     <div id="selection-bar"></div>
     <div id="glyph" class="glyph" draggable="true"></div>
-    <div id="glyph2" class="glyph" draggable="true">
-      <svg width="40" height="40">
-        <line x1="6" y1="34" x2="34" y2="6" stroke="#3fc009" stroke-width="2"/>
-        <circle cx="6" cy="34" r="7" fill="#3fc009"/>
-        <circle cx="34" cy="6" r="7" fill="#3fc009"/>
+    <div id="glyph2a" class="glyph" draggable="true" data-glyph="glyph2a">
+      <svg width="14" height="14">
+        <circle cx="7" cy="7" r="7" fill="#3fc009"/>
+      </svg>
+    </div>
+    <div id="glyph2b" class="glyph" draggable="true" data-glyph="glyph2b">
+      <svg width="14" height="14">
+        <circle cx="7" cy="7" r="7" fill="#3fc009"/>
       </svg>
     </div>
   </body>

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -18,7 +18,8 @@ export default class GlyphController {
         document.body.appendChild(clone);
         const rect = glyph.getBoundingClientRect();
         e.dataTransfer.setDragImage(clone, rect.width / 2, rect.height / 2);
-        e.dataTransfer.setData('text/plain', 'glyph');
+        const id = glyph.dataset.glyph || 'glyph';
+        e.dataTransfer.setData('text/plain', id);
         setTimeout(() => document.body.removeChild(clone), 0);
       });
     });
@@ -32,6 +33,7 @@ export default class GlyphController {
         e.preventDefault();
         btn.style.backgroundColor = '#3fc009';
 
+        const glyphId = e.dataTransfer.getData('text/plain');
         const name = btn.dataset.name || btn.textContent.trim();
 
         // Determine horizontal ratio of drop within the gesture grid
@@ -47,6 +49,9 @@ export default class GlyphController {
         field.style.width = '56px';
         field.style.fontSize = '8px';
         field.style.height = '20px';
+        if (glyphId) {
+          field.dataset.glyph = glyphId;
+        }
         this.bar.appendChild(field);
         this._markDisplay(name, ratio);
       });

--- a/styles.css
+++ b/styles.css
@@ -61,12 +61,20 @@ h1 {
     border-radius: 50%;
   }
 
-  #glyph2 {
-    right: 50px; /* adjust position as needed */
-    top: 50%;
-    transform: translateY(-50%);
-    width: 40px;
-    height: 40px;
+  #glyph2a,
+  #glyph2b {
+    width: 14px;
+    height: 14px;
+  }
+
+  #glyph2a {
+    right: 77px;
+    top: calc(50% + 7px);
+  }
+
+  #glyph2b {
+    right: 49px;
+    top: calc(50% - 21px);
   }
 
 #selection-bar {


### PR DESCRIPTION
## Summary
- Replace single glyph2 wrapper with two draggable circle elements.
- Position new glyphs with dedicated styles.
- Carry glyph identifiers through drag and drop to support distinct handling.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5b52d2128833294e1720dfa717547