### PR TITLE
Combine glyph2 circles into single connected glyph

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,11 @@
   <body>
     <div id="selection-bar"></div>
     <div id="glyph" class="glyph" draggable="true"></div>
-    <div id="glyph2a" class="glyph" draggable="true" data-glyph="glyph2a">
-      <svg width="14" height="14">
-        <circle cx="7" cy="7" r="7" fill="#3fc009"/>
-      </svg>
-    </div>
-    <div id="glyph2b" class="glyph" draggable="true" data-glyph="glyph2b">
-      <svg width="14" height="14">
-        <circle cx="7" cy="7" r="7" fill="#3fc009"/>
+    <div id="glyph2" class="glyph" draggable="true" data-glyph="glyph2">
+      <svg width="42" height="42">
+        <line x1="35" y1="7" x2="7" y2="35" stroke="#3fc009" stroke-width="2" />
+        <circle cx="35" cy="7" r="7" fill="#3fc009" />
+        <circle cx="7" cy="35" r="7" fill="#3fc009" />
       </svg>
     </div>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -61,20 +61,11 @@ h1 {
     border-radius: 50%;
   }
 
-  #glyph2a,
-  #glyph2b {
-    width: 14px;
-    height: 14px;
-  }
-
-  #glyph2a {
-    right: 77px;
-    top: calc(50% + 7px);
-  }
-
-  #glyph2b {
+  #glyph2 {
     right: 49px;
     top: calc(50% - 21px);
+    width: 42px;
+    height: 42px;
   }
 
 #selection-bar {


### PR DESCRIPTION
## Summary
- Replace separate glyph2a/glyph2b divs with a single glyph2 container
- Embed two circles and a connecting line in one SVG so the shape moves as a unit
- Simplify styles by removing old glyph2a/b rules and adding glyph2 styles

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9b9d5ce8483329a1cfc91b38be6ef