### PR TITLE
Style internal line for grouped glyph2

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
   <body>
     <div id="selection-bar"></div>
     <div id="glyph" class="glyph" draggable="true"></div>
-    <div id="glyph2" class="glyph" draggable="true" data-glyph="glyph2">
-      <svg width="42" height="42">
-        <line x1="35" y1="7" x2="7" y2="35" stroke="#3fc009" stroke-width="2" />
-        <circle cx="35" cy="7" r="7" fill="#3fc009" />
-        <circle cx="7" cy="35" r="7" fill="#3fc009" />
-      </svg>
-    </div>
+      <div id="glyph2" class="glyph" draggable="true" data-glyph="glyph2">
+        <svg width="42" height="42">
+          <line x1="35" y1="7" x2="7" y2="35" />
+          <circle cx="35" cy="7" r="7" fill="#3fc009" />
+          <circle cx="7" cy="35" r="7" fill="#3fc009" />
+        </svg>
+      </div>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,11 @@ h1 {
     height: 42px;
   }
 
+  #glyph2 line {
+    stroke: #3fc009;
+    stroke-width: 2;
+  }
+
 #selection-bar {
   position: fixed;
   top: 130px;


### PR DESCRIPTION
## Summary
- Replace legacy glyph2a/b CSS with a single `#glyph2` rule for positioning the grouped glyph
- Style glyph2's internal line via CSS for color and stroke width

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9bad533288332839ea02cac1b7017