### PR TITLE
Refactor glyph handling for consistent data attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <div id="selection-bar"></div>
-    <div id="glyph" class="glyph" draggable="true"></div>
+    <div id="glyph" class="glyph" draggable="true" data-glyph="glyph"></div>
       <div id="glyph2" class="glyph" draggable="true" data-glyph="glyph2">
         <svg width="42" height="42">
           <line x1="35" y1="7" x2="7" y2="35" />

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -1,6 +1,6 @@
 export default class GlyphController {
   constructor({ timelineDisplays = {} } = {}) {
-    this.glyphSelector = '.glyph, #glyph2';
+    this.glyphSelector = '.glyph';
     this.glyphs = document.querySelectorAll(this.glyphSelector);
     this.bar = document.getElementById('selection-bar');
     this.timelineDisplays = timelineDisplays;
@@ -73,7 +73,7 @@ export default class GlyphController {
         field.style.fontSize = '8px';
         field.style.height = '20px';
         if (glyphId) {
-          field.dataset.glyph = glyphId.startsWith('glyph2') ? 'glyph2' : glyphId;
+          field.dataset.glyph = glyphId;
         }
         this.bar.appendChild(field);
         this._markDisplay(name, ratio);


### PR DESCRIPTION
## Summary
- Simplify glyph lookup to rely solely on the `.glyph` class
- Remove special-case logic for `glyph2` and store drag data directly
- Ensure both glyph elements carry a `data-glyph` attribute

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9bf9aef908332b84528c4d4a358ec