### PR TITLE
Handle prong-specific glyph drops

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
       <div id="glyph2" class="glyph" draggable="true" data-glyph="glyph2">
         <svg width="42" height="42">
           <line x1="35" y1="7" x2="7" y2="35" />
-          <circle cx="35" cy="7" r="7" fill="#3fc009" />
-          <circle cx="7" cy="35" r="7" fill="#3fc009" />
+          <circle data-prong="right" cx="35" cy="7" r="7" fill="#3fc009" />
+          <circle data-prong="left" cx="7" cy="35" r="7" fill="#3fc009" />
         </svg>
       </div>
   </body>

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -5,6 +5,8 @@ export default class GlyphController {
     this.bar = document.getElementById('selection-bar');
     this.timelineDisplays = timelineDisplays;
     this.currentGlyph = null;
+    this.currentProng = null;
+    this.pendingPairInput = null;
     this.dragOffset = { x: 0, y: 0 };
     if (!this.glyphs.length || !this.bar) return;
     this._setupGlyphs();
@@ -16,6 +18,8 @@ export default class GlyphController {
       const glyph = e.target.closest(this.glyphSelector);
       if (!glyph) return;
       this.currentGlyph = glyph;
+      const prong = e.target.dataset.prong;
+      this.currentProng = prong || null;
 
       // Cache original inline style so we can restore it after a drop
       glyph.dataset.originalStyle = glyph.getAttribute('style') || '';
@@ -31,6 +35,9 @@ export default class GlyphController {
       e.dataTransfer.setDragImage(clone, rect.width / 2, rect.height / 2);
       const id = glyph.dataset.glyph || 'glyph';
       e.dataTransfer.setData('text/plain', id);
+      if (prong) {
+        e.dataTransfer.setData('prong', prong);
+      }
       setTimeout(() => document.body.removeChild(clone), 0);
     });
 
@@ -45,6 +52,7 @@ export default class GlyphController {
       glyph.style.right = 'auto';
       glyph.style.transform = 'none';
       this.currentGlyph = null;
+      this.currentProng = null;
     });
   }
 
@@ -58,6 +66,7 @@ export default class GlyphController {
 
         const glyphId = e.dataTransfer.getData('text/plain');
         const name = btn.dataset.name || btn.textContent.trim();
+        const prong = e.dataTransfer.getData('prong');
 
         // Determine horizontal ratio of drop within the gesture grid
         const container = btn.parentElement || document.body;
@@ -65,18 +74,65 @@ export default class GlyphController {
         let ratio = (e.clientX - rect.left) / rect.width;
         ratio = Math.min(Math.max(ratio, 0), 1);
 
-        const field = document.createElement('input');
-        field.type = 'text';
-        field.value = name;
-        field.readOnly = true;
-        field.style.width = '56px';
-        field.style.fontSize = '8px';
-        field.style.height = '20px';
-        if (glyphId) {
-          field.dataset.glyph = glyphId;
+        if (prong === 'left') {
+          const first = document.createElement('input');
+          first.type = 'text';
+          first.value = name;
+          first.readOnly = true;
+          first.style.width = '56px';
+          first.style.fontSize = '8px';
+          first.style.height = '20px';
+          if (glyphId) {
+            first.dataset.glyph = glyphId;
+          }
+          const second = document.createElement('input');
+          second.type = 'text';
+          second.readOnly = true;
+          second.style.width = '56px';
+          second.style.fontSize = '8px';
+          second.style.height = '20px';
+          this.bar.appendChild(first);
+          this.bar.appendChild(second);
+          this.pendingPairInput = second;
+          this._markDisplay(name, ratio);
+
+          // Update glyph for left prong placement
+          const glyph = this.currentGlyph;
+          if (glyph) {
+            const svg = glyph.querySelector('svg');
+            const line = svg && svg.querySelector('line');
+            const leftCircle = svg && svg.querySelector('[data-prong="left"]');
+            if (leftCircle) leftCircle.style.display = 'none';
+            if (svg && line) {
+              const svgRect = svg.getBoundingClientRect();
+              const btnRect = btn.getBoundingClientRect();
+              const x = btnRect.left + btnRect.width / 2 - svgRect.left;
+              const y = btnRect.top + btnRect.height / 2 - svgRect.top;
+              line.setAttribute('x2', x);
+              line.setAttribute('y2', y);
+            }
+          }
+        } else {
+          let field;
+          if (prong === 'right' && this.pendingPairInput) {
+            field = this.pendingPairInput;
+            field.value = name;
+            this.pendingPairInput = null;
+          } else {
+            field = document.createElement('input');
+            field.type = 'text';
+            field.value = name;
+            field.readOnly = true;
+            field.style.width = '56px';
+            field.style.fontSize = '8px';
+            field.style.height = '20px';
+            if (glyphId) {
+              field.dataset.glyph = glyphId;
+            }
+            this.bar.appendChild(field);
+          }
+          this._markDisplay(name, ratio);
         }
-        this.bar.appendChild(field);
-        this._markDisplay(name, ratio);
 
         // Restore glyph to its original docked style and position
         if (this.currentGlyph) {
@@ -86,6 +142,18 @@ export default class GlyphController {
           glyph.style.removeProperty('top');
           glyph.style.removeProperty('right');
           glyph.style.removeProperty('transform');
+          if (!this.pendingPairInput) {
+            const svg = glyph.querySelector('svg');
+            const line = svg && svg.querySelector('line');
+            const leftCircle = svg && svg.querySelector('[data-prong="left"]');
+            if (leftCircle) leftCircle.style.display = '';
+            if (line) {
+              line.setAttribute('x1', '35');
+              line.setAttribute('y1', '7');
+              line.setAttribute('x2', '7');
+              line.setAttribute('y2', '35');
+            }
+          }
           this.currentGlyph = null;
         }
       });


### PR DESCRIPTION
## Summary
- Add `data-prong` markers to the two-pronged glyph circles
- Track which prong is dragged and handle left/right drop behavior separately
- On left-prong drops append paired inputs and hide the left circle while relocating the line anchor

## Testing
- ⚠️ `npm test` *(missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c20c99648332a223e1ea9ecfbae3