### PR TITLE
Use drag offset for glyph drag image

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -32,7 +32,7 @@ export default class GlyphController {
       clone.style.top = '-9999px';
       clone.style.right = '-9999px';
       document.body.appendChild(clone);
-      e.dataTransfer.setDragImage(clone, rect.width / 2, rect.height / 2);
+      e.dataTransfer.setDragImage(clone, this.dragOffset.x, this.dragOffset.y);
       const id = glyph.dataset.glyph || 'glyph';
       e.dataTransfer.setData('text/plain', id);
       if (prong) {


### PR DESCRIPTION
## Summary
- ensure dragged glyph image uses cursor offset to keep cursor anchored on selected prong

## Testing
- `npm test` *(fails: Missing script "test" error)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c55d3140833290b175d342754bca