### PR TITLE
Support glyph2 drop pairing without prong

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -81,7 +81,7 @@ export default class GlyphController {
           y: btnRect.top + btnRect.height / 2,
         };
 
-        if (prong === 'left') {
+        if (prong === 'left' || (!prong && glyphId === 'glyph2')) {
           const first = document.createElement('input');
           first.type = 'text';
           first.value = name;
@@ -98,6 +98,7 @@ export default class GlyphController {
           second.style.width = '56px';
           second.style.fontSize = '8px';
           second.style.height = '20px';
+          second.value = '';
           this.bar.appendChild(first);
           this.bar.appendChild(second);
           this.pendingPairInput = second;


### PR DESCRIPTION
## Summary
- Allow `glyph2` drops without a prong to create paired input fields
- Populate first input with gesture name and leave second empty for later right-prong drops

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb8c1d148332986792c69c0f6208