### PR TITLE
Keep glyph anchored when dragging remaining prongs

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -46,14 +46,16 @@ export default class GlyphController {
 
     document.addEventListener('dragend', (e) => {
       if (!this.currentGlyph) return;
-      const left = e.clientX - this.dragOffset.x;
-      const top = e.clientY - this.dragOffset.y;
       const glyph = this.currentGlyph;
-      glyph.style.position = 'fixed';
-      glyph.style.left = `${left}px`;
-      glyph.style.top = `${top}px`;
-      glyph.style.right = 'auto';
-      glyph.style.transform = 'none';
+      if (!this.currentProng) {
+        const left = e.clientX - this.dragOffset.x;
+        const top = e.clientY - this.dragOffset.y;
+        glyph.style.position = 'fixed';
+        glyph.style.left = `${left}px`;
+        glyph.style.top = `${top}px`;
+        glyph.style.right = 'auto';
+        glyph.style.transform = 'none';
+      }
       this.currentGlyph = null;
       this.currentProng = null;
     });
@@ -169,9 +171,6 @@ export default class GlyphController {
               }
             }
           });
-
-          this.currentGlyph = null;
-          this.currentProng = null;
         }
       });
     });


### PR DESCRIPTION
## Summary
- Avoid repositioning glyph on dragend when a prong is being dragged
- Update drop handler to only move the dragged prong's circle/line endpoint, keeping first drop anchored

## Testing
- `node --input-type=module - <<'NODE' ... NODE`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9cf2464ac83328e4ad945f470971a