### PR TITLE
Allow either prong to anchor first in glyph drop logic

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -124,7 +124,7 @@ export default class GlyphController {
           y: btnRect.top + btnRect.height / 2,
         };
 
-        if (prong === 'left' || (!prong && glyphId === 'glyph2')) {
+        if (this.pendingPairInput === null && prong) {
           const first = document.createElement('input');
           first.type = 'text';
           first.value = name;
@@ -148,7 +148,7 @@ export default class GlyphController {
           this._markDisplay(name, ratio);
         } else {
           let field;
-          if (prong === 'right' && this.pendingPairInput) {
+          if (prong && this.pendingPairInput) {
             field = this.pendingPairInput;
             field.value = name;
             this.pendingPairInput = null;


### PR DESCRIPTION
## Summary
- Use `pendingPairInput` to detect first prong drop
- Anchor whichever prong is dropped first and compute the remaining prong dynamically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b9d83561748332bbb56d897fef2184