### PR TITLE
Handle two-prong glyph drops

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -124,7 +124,13 @@ export default class GlyphController {
           y: btnRect.top + btnRect.height / 2,
         };
 
-        if (this.pendingPairInput === null && prong) {
+        // Also create paired inputs when a glyph with two prongs is dropped
+        const hasTwoProngs =
+          glyphId === 'glyph2' ||
+          (this.currentGlyph &&
+            this.currentGlyph.querySelectorAll('circle[data-prong]').length === 2);
+
+        if (this.pendingPairInput === null && (prong || hasTwoProngs)) {
           const first = document.createElement('input');
           first.type = 'text';
           first.value = name;


### PR DESCRIPTION
## Summary
- Treat glyphs with two prongs (e.g., `glyph2`) like paired inputs even when dropped without specifying a prong
- Detect two-prong glyphs and initialize paired text inputs on first drop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b9da308fb0833292dc3f60b591008a