### PR TITLE
Allow second prong spawn at drop location

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -150,9 +150,10 @@ export default class GlyphController {
           this._markDisplay(name, ratio);
         }
 
-        if (prong && this.otherCircleOffset) {
-          const left = e.clientX + this.otherCircleOffset.x;
-          const top = e.clientY + this.otherCircleOffset.y;
+        if (prong) {
+          const offset = this.otherCircleOffset || { x: 0, y: 0 };
+          const left = e.clientX + offset.x;
+          const top = e.clientY + offset.y;
           this._spawnSingleGlyph(left, top);
           this.otherCircleOffset = null;
         }


### PR DESCRIPTION
## Summary
- Ensure second prong spawns at drop location when no offset is available

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba0f676dac833284b669d43ef7637a