### PR TITLE
Ensure second prong input is populated for paired glyphs

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -127,7 +127,7 @@ export default class GlyphController {
             this.currentGlyph.remove();
             this.currentGlyph = null;
           }
-          this.pendingPairInput = null;
+          this.pendingPairInput = second;
         } else {
           let field;
           if (prong && this.pendingPairInput) {


### PR DESCRIPTION
## Summary
- After creating two inputs for pronged glyphs, track the second field so the subsequent drop fills it.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba11067f8c8332aaf2209837f0406f