### PR TITLE
Spawn circle when dropping entire glyph2

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -150,8 +150,10 @@ export default class GlyphController {
           this._markDisplay(name, ratio);
         }
 
-        if (prong) {
-          const offset = this.otherCircleOffset || { x: 0, y: 0 };
+        if (prong || hasTwoProngs) {
+          const offset = prong
+            ? this.otherCircleOffset || { x: 0, y: 0 }
+            : { x: 0, y: 0 };
           const left = e.clientX + offset.x;
           const top = e.clientY + offset.y;
           this._spawnSingleGlyph(left, top);


### PR DESCRIPTION
## Summary
- Allow dropping whole two-prong glyph to spawn a single circle
- Default lone-circle spawn offset when no specific prong is dropped

## Testing
- `node test-drop.mjs`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba130b5c108332904af0c9d28c0d3b