### PR TITLE
Offset spawned glyph from cursor

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -154,8 +154,8 @@ export default class GlyphController {
           const offset = prong
             ? this.otherCircleOffset || { x: 0, y: 0 }
             : { x: 0, y: 0 };
-          const left = e.clientX + offset.x;
-          const top = e.clientY + offset.y;
+          const left = e.clientX + offset.x + 15;
+          const top = e.clientY + offset.y + 15;
           this._spawnSingleGlyph(left, top);
           this.otherCircleOffset = null;
         }


### PR DESCRIPTION
## Summary
- offset spawned glyph position by 15px relative to drop cursor

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba1677e23083329b7b56b9cba66960