### PR TITLE
Connect glyph prongs with SVG lines

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -62,6 +62,7 @@ export default class GlyphController {
     this.currentGlyph = null;
     this.currentProng = null;
     this.pendingPairInput = null;
+    this.pendingPairPath = null;
     this.dragOffset = { x: 0, y: 0 };
     this.otherCircleOffset = null;
     const template = document.getElementById('glyph2');
@@ -205,7 +206,10 @@ export default class GlyphController {
           second.value = '';
           this.bar.appendChild(first);
           this.bar.appendChild(second);
-          this._markDisplay(name, ratio);
+          const mark = this._markDisplay(name, ratio);
+          if (mark) {
+            this.pendingPairPath = mark.path;
+          }
 
           if (this.currentGlyph) {
             this.currentGlyph.remove();
@@ -215,7 +219,11 @@ export default class GlyphController {
         } else if (this.pendingPairInput) {
           this.pendingPairInput.value = name;
           this.pendingPairInput = null;
-          this._markDisplay(name, ratio);
+          const mark = this._markDisplay(name, ratio);
+          if (mark && this.pendingPairPath) {
+            mark.display.addConnection(this.pendingPairPath, mark.path);
+            this.pendingPairPath = null;
+          }
           if (isSingleBlue && this.currentGlyph) {
             if (typeof this.currentGlyph._removeConnector === 'function') {
               this.currentGlyph._removeConnector();
@@ -332,6 +340,8 @@ export default class GlyphController {
     if (display) {
       const path = pathParts.join('.') || 'C';
       display.addMarker(path, ratio);
+      return { display, path };
     }
+    return null;
   }
 }

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -85,4 +85,23 @@ export default class TimelineDisplay {
 
     circle.classList.add('glyph-marker');
   }
+
+  /**
+   * Draw a connector line between two marker paths.
+   * @param {string} firstPath
+   * @param {string} secondPath
+   */
+  addConnection(firstPath, secondPath) {
+    if (!this.svg) return;
+    const p1 = this.positionMap[firstPath];
+    const p2 = this.positionMap[secondPath];
+    if (!p1 || !p2) return;
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', p1.x);
+    line.setAttribute('y1', p1.y);
+    line.setAttribute('x2', p2.x);
+    line.setAttribute('y2', p2.y);
+    line.setAttribute('class', 'glyph-connector');
+    this.svg.appendChild(line);
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -122,3 +122,8 @@ h1 {
 .timeline-display .glyph-marker {
   fill: #3fc009;
 }
+
+.timeline-display .glyph-connector {
+  stroke: #3fc009;
+  stroke-width: 1;
+}


### PR DESCRIPTION
## Summary
- Track first prong path during glyph drops to connect paired markers
- Draw connector lines between markers using timeline display positions
- Style connector lines in the timeline SVG

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c31d1ad3208332b0a0c8825224b6e3