### PR TITLE
Add cross-display timeline connectors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,19 @@ new p5((p) => {
       spatialUIController: spatialUI,
     });
     const wrapper = p.createDiv('').id('timeline-wrapper');
+    const connectorLayer = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'svg'
+    );
+    connectorLayer.id = 'timeline-connector-layer';
+    connectorLayer.style.pointerEvents = 'none';
+    connectorLayer.style.position = 'fixed';
+    connectorLayer.style.top = '0';
+    connectorLayer.style.left = '0';
+    connectorLayer.style.width = '100%';
+    connectorLayer.style.height = '100%';
+    connectorLayer.style.zIndex = '1100';
+    wrapper.elt.appendChild(connectorLayer);
     timeline1 = new TimelineDisplay(p, 'timeline-display-1');
     timeline1.build();
     timeline1.container.parent(wrapper);

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -62,7 +62,7 @@ export default class GlyphController {
     this.currentGlyph = null;
     this.currentProng = null;
     this.pendingPairInput = null;
-    this.pendingPairPath = null;
+    this.pendingPairMark = null;
     this.dragOffset = { x: 0, y: 0 };
     this.otherCircleOffset = null;
     const template = document.getElementById('glyph2');
@@ -208,7 +208,10 @@ export default class GlyphController {
           this.bar.appendChild(second);
           const mark = this._markDisplay(name, ratio);
           if (mark) {
-            this.pendingPairPath = mark.path;
+            this.pendingPairMark = {
+              display: mark.display,
+              path: mark.path,
+            };
           }
 
           if (this.currentGlyph) {
@@ -220,9 +223,36 @@ export default class GlyphController {
           this.pendingPairInput.value = name;
           this.pendingPairInput = null;
           const mark = this._markDisplay(name, ratio);
-          if (mark && this.pendingPairPath) {
-            mark.display.addConnection(this.pendingPairPath, mark.path);
-            this.pendingPairPath = null;
+          if (mark && this.pendingPairMark) {
+            if (mark.display !== this.pendingPairMark.display) {
+              const layer = document.getElementById(
+                'timeline-connector-layer'
+              );
+              if (layer) {
+                const start = this.pendingPairMark.display.getMarkerScreenPos(
+                  this.pendingPairMark.path
+                );
+                const end = mark.display.getMarkerScreenPos(mark.path);
+                if (start && end) {
+                  const line = document.createElementNS(
+                    'http://www.w3.org/2000/svg',
+                    'line'
+                  );
+                  line.setAttribute('x1', start.x);
+                  line.setAttribute('y1', start.y);
+                  line.setAttribute('x2', end.x);
+                  line.setAttribute('y2', end.y);
+                  line.setAttribute('class', 'timeline-connector');
+                  layer.appendChild(line);
+                }
+              }
+            } else {
+              mark.display.addConnection(
+                this.pendingPairMark.path,
+                mark.path
+              );
+            }
+            this.pendingPairMark = null;
           }
           if (isSingleBlue && this.currentGlyph) {
             if (typeof this.currentGlyph._removeConnector === 'function') {

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -72,6 +72,13 @@ export default class TimelineDisplay {
     };
   }
 
+  getMarkerScreenPos(path) {
+    const el = this.tokenMap[path];
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  }
+
   /**
    * Add a green marker at the given path and horizontal ratio.
    * @param {string} path dotted path such as 'UR.DR'

--- a/styles.css
+++ b/styles.css
@@ -94,6 +94,16 @@ h1 {
   z-index: 1000;
 }
 
+#timeline-connector-layer {
+  pointer-events: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1100;
+}
+
 .timeline-display {
   width: 120px;
   height: 120px;
@@ -124,6 +134,11 @@ h1 {
 }
 
 .timeline-display .glyph-connector {
+  stroke: #3fc009;
+  stroke-width: 1;
+}
+
+.timeline-connector {
   stroke: #3fc009;
   stroke-width: 1;
 }


### PR DESCRIPTION
## Summary
- track pending marker's display and path for prong pairing
- add global connector layer for cross-display links
- compute screen positions and draw connectors across timeline displays

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c320c7ed148332aa32718858a26a78