### PR TITLE
Keep timeline connector layer sized to viewport

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,16 @@ new p5((p) => {
     connectorLayer.style.height = '100%';
     connectorLayer.style.zIndex = '1100';
     wrapper.elt.appendChild(connectorLayer);
+    const updateConnectorLayerSize = () => {
+      connectorLayer.setAttribute('width', window.innerWidth);
+      connectorLayer.setAttribute('height', window.innerHeight);
+      connectorLayer.setAttribute(
+        'viewBox',
+        `0 0 ${window.innerWidth} ${window.innerHeight}`
+      );
+    };
+    updateConnectorLayerSize();
+    window.addEventListener('resize', updateConnectorLayerSize);
     timeline1 = new TimelineDisplay(p, 'timeline-display-1');
     timeline1.build();
     timeline1.container.parent(wrapper);


### PR DESCRIPTION
## Summary
- add updateConnectorLayerSize to set connector layer width, height and viewBox
- call function on initialization and window resize so SVG matches viewport

## Testing
- `npm test` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68c322a60ac08332a961c8627d817f10