### PR TITLE
Fix connector layer positioning to span viewport

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -45,7 +45,7 @@ new p5((p) => {
     connectorLayer.style.width = '100%';
     connectorLayer.style.height = '100%';
     connectorLayer.style.zIndex = '1100';
-    wrapper.elt.appendChild(connectorLayer);
+    document.body.appendChild(connectorLayer);
     const updateConnectorLayerSize = () => {
       connectorLayer.setAttribute('width', window.innerWidth);
       connectorLayer.setAttribute('height', window.innerHeight);


### PR DESCRIPTION
## Summary
- Attach SVG connector layer directly to `document.body` to avoid wrapper transforms
- Maintain fixed positioning and update sizing using window dimensions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c325adccec8332bdc3e30831f221b9