### PR TITLE
Handle single glyph drops with input and timeline mark

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -276,6 +276,23 @@ export default class GlyphController {
             this.currentGlyph = null;
           }
           this._spawnTwoProngGlyph();
+        } else if (glyphId === 'glyph') {
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.readOnly = true;
+          input.style.width = '56px';
+          input.style.fontSize = '8px';
+          input.style.height = '20px';
+          input.value = name;
+          if (glyphId) {
+            input.dataset.glyph = glyphId;
+          }
+          this.bar.appendChild(input);
+          this._markDisplay(name, ratio);
+          if (this.currentGlyph) {
+            this.currentGlyph.remove();
+            this.currentGlyph = null;
+          }
         } else {
           // existing logic to spawn another text box is skipped
         }


### PR DESCRIPTION
## Summary
- Create read-only input when a single glyph is dropped on a gesture button
- Mark the timeline at the drop position and remove the dragged glyph

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c32cf03cb4833289a9e1bb07a53893