### PR TITLE
Clear previous glyph on drop

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -298,6 +298,10 @@ export default class GlyphController {
         }
 
         if (prong || hasTwoProngs) {
+          if (this.currentGlyph) {
+            this.currentGlyph.remove();
+            this.currentGlyph = null;
+          }
           const offset = prong
             ? this.otherCircleOffset || { x: 0, y: 0 }
             : { x: 0, y: 0 };


### PR DESCRIPTION
## Summary
- Remove existing glyph before spawning a new SingleBlueGlyph when dropping prongs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c33055b8688332970e3991b48964e0