### PR TITLE
Center selection bar and dynamic reposition

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -65,6 +65,10 @@ export default class GlyphController {
     this.pendingPairMark = null;
     this.dragOffset = { x: 0, y: 0 };
     this.otherCircleOffset = null;
+    if (this.bar) {
+      this._centerSelectionBar();
+      window.addEventListener('resize', () => this._centerSelectionBar());
+    }
     const glyph1 = document.getElementById('glyph');
     this.glyph1Template = glyph1 ? glyph1.cloneNode(true) : null;
     if (this.glyph1Template) {
@@ -220,6 +224,7 @@ export default class GlyphController {
           second.value = '';
           this.bar.appendChild(first);
           this.bar.appendChild(second);
+          this._centerSelectionBar();
           const mark = this._markDisplay(name, ratio);
           if (mark) {
             this.pendingPairMark = {
@@ -288,6 +293,7 @@ export default class GlyphController {
             input.dataset.glyph = glyphId;
           }
           this.bar.appendChild(input);
+          this._centerSelectionBar();
           this._markDisplay(name, ratio);
           if (this.currentGlyph) {
             this.currentGlyph.remove();
@@ -346,6 +352,12 @@ export default class GlyphController {
         }
       });
     });
+  }
+
+  _centerSelectionBar() {
+    if (!this.bar) return;
+    const width = this.bar.getBoundingClientRect().width;
+    this.bar.style.marginLeft = `-${width / 2}px`;
   }
 
   _spawnSingleGlyph(left, top, anchor) {

--- a/styles.css
+++ b/styles.css
@@ -74,13 +74,13 @@ h1 {
   }
 
 #selection-bar {
-  position: fixed;
-  top: 130px;
-  left: 0;
-  display: flex;
-  gap: 6px;
-  padding: 6px;
-  z-index: 1000;
+    position: fixed;
+    top: 130px;
+    left: 50%;
+    display: flex;
+    gap: 6px;
+    padding: 6px;
+    z-index: 1000;
 }
 
 #timeline-wrapper {


### PR DESCRIPTION
## Summary
- Center selection bar beneath timeline and adjust its position for added text boxes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c33232844c8332a42abb45c94de450