### PR TITLE
feat: add glyph undo functionality

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,10 @@ new p5((p) => {
     timeline2.build();
     timeline2.container.parent(wrapper);
 
-    new GlyphController({ timelineDisplays: { L: timeline1, R: timeline2 } });
+    const glyphCtrl = new GlyphController({
+      timelineDisplays: { L: timeline1, R: timeline2 },
+    });
+    systemUI.setGlyphController(glyphCtrl);
 
     // ─── OPTIONAL SPATIALUI CALLBACKS ─────────────────────────────────────────
     spatialUI.setGestureCallback((name) => {

--- a/src/ui/buttonPanelController.js
+++ b/src/ui/buttonPanelController.js
@@ -71,6 +71,7 @@ export default class ButtonPanelController {
     makeBtn('copyState', 'Copy State', 80);
     makeBtn('clearWeight', 'Clear Weight', 80);
     makeBtn('clearGesture', 'Clear Gesture', 80);
+    makeBtn('undoGlyph', 'Undo Glyph', 80);
     makeBtn('playSeq', 'Play Sequence', 120);
     makeBtn('nextSeq', 'Next Sequence', 120);
   }

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -63,8 +63,10 @@ export default class GlyphController {
     this.currentProng = null;
     this.pendingPairInput = null;
     this.pendingPairMark = null;
+    this.pendingPairRecord = null;
     this.dragOffset = { x: 0, y: 0 };
     this.otherCircleOffset = null;
+    this.actionStack = [];
     if (this.bar) {
       this._centerSelectionBar();
       window.addEventListener('resize', () => this._centerSelectionBar());
@@ -226,11 +228,17 @@ export default class GlyphController {
           this.bar.appendChild(second);
           this._centerSelectionBar();
           const mark = this._markDisplay(name, ratio);
+          const record = {
+            inputs: [first, second],
+            markers: [],
+            connectors: [],
+          };
           if (mark) {
             this.pendingPairMark = {
               display: mark.display,
               path: mark.path,
             };
+            record.markers.push(this.pendingPairMark);
           }
 
           if (this.currentGlyph) {
@@ -238,9 +246,15 @@ export default class GlyphController {
             this.currentGlyph = null;
           }
           this.pendingPairInput = second;
+          this.pendingPairRecord = record;
         } else if (this.pendingPairInput) {
           this.pendingPairInput.value = name;
           this.pendingPairInput = null;
+          const record = this.pendingPairRecord || {
+            inputs: [],
+            markers: [],
+            connectors: [],
+          };
           const mark = this._markDisplay(name, ratio);
           if (mark && this.pendingPairMark) {
             if (mark.display !== this.pendingPairMark.display) {
@@ -263,14 +277,19 @@ export default class GlyphController {
                   line.setAttribute('y2', end.y);
                   line.setAttribute('class', 'timeline-connector');
                   layer.appendChild(line);
+                  record.connectors.push({ line });
                 }
               }
             } else {
-              mark.display.addConnection(
+              const line = mark.display.addConnection(
                 this.pendingPairMark.path,
                 mark.path
               );
+              if (line) {
+                record.connectors.push({ line, display: mark.display });
+              }
             }
+            record.markers.push({ display: mark.display, path: mark.path });
             this.pendingPairMark = null;
           }
           if (isSingleBlue && this.currentGlyph) {
@@ -281,6 +300,8 @@ export default class GlyphController {
             this.currentGlyph = null;
           }
           this._spawnTwoProngGlyph();
+          this.actionStack.push(record);
+          this.pendingPairRecord = null;
         } else if (glyphId === 'glyph') {
           const input = document.createElement('input');
           input.type = 'text';
@@ -294,11 +315,19 @@ export default class GlyphController {
           }
           this.bar.appendChild(input);
           this._centerSelectionBar();
-          this._markDisplay(name, ratio);
+          const mark = this._markDisplay(name, ratio);
           if (this.currentGlyph) {
             this.currentGlyph.remove();
             this.currentGlyph = null;
           }
+          const record = {
+            inputs: [input],
+            markers: mark
+              ? [{ display: mark.display, path: mark.path }]
+              : [],
+            connectors: [],
+          };
+          this.actionStack.push(record);
         } else {
           // existing logic to spawn another text box is skipped
         }
@@ -351,6 +380,39 @@ export default class GlyphController {
           });
         }
       });
+    });
+  }
+
+  undoLastGlyph() {
+    if (this.pendingPairRecord) {
+      this.pendingPairRecord.inputs.forEach((el) => el.remove());
+      this.pendingPairRecord.markers.forEach(({ display, path }) =>
+        display.removeMarker(path)
+      );
+      this.pendingPairRecord.connectors.forEach(({ line, display }) => {
+        if (display && typeof display.removeConnection === 'function') {
+          display.removeConnection(line);
+        } else if (line && typeof line.remove === 'function') {
+          line.remove();
+        }
+      });
+      this.pendingPairRecord = null;
+      this.pendingPairInput = null;
+      this.pendingPairMark = null;
+      this._centerSelectionBar();
+      return;
+    }
+    const last = this.actionStack.pop();
+    if (!last) return;
+    last.inputs.forEach((el) => el.remove());
+    this._centerSelectionBar();
+    last.markers.forEach(({ display, path }) => display.removeMarker(path));
+    last.connectors.forEach(({ line, display }) => {
+      if (display && typeof display.removeConnection === 'function') {
+        display.removeConnection(line);
+      } else if (line && typeof line.remove === 'function') {
+        line.remove();
+      }
     });
   }
 

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -17,6 +17,7 @@ export default class SystemUIController {
     this.canvasRenderer = canvasRenderer;
     this.spatialUIController = spatialUIController;
     this.sequenceManager = sequences;
+    this.glyphController = null;
 
     // UI state
     this.timerMode = 0; // 0=Whole,1=One And,2=And One,3=Quarter
@@ -89,6 +90,7 @@ export default class SystemUIController {
           `Weights: ${this.weightsVisible ? 'On' : 'Off'}`
         );
       },
+      undoGlyph: () => this.glyphController?.undoLastGlyph(),
       copyState: () => this.copyState(),
       playSeq: () => this.loadFirstSequence(),
       nextSeq: () => this.loadNextSequence(),
@@ -261,5 +263,9 @@ export default class SystemUIController {
     this.p.textAlign(this.p.RIGHT, this.p.TOP);
     this.p.text(this.timer.getTimerDisplay(), this.p.width - 320, 110);
     this.p.pop();
+  }
+
+  setGlyphController(controller) {
+    this.glyphController = controller;
   }
 }

--- a/src/ui/timelineDisplay.js
+++ b/src/ui/timelineDisplay.js
@@ -94,6 +94,18 @@ export default class TimelineDisplay {
   }
 
   /**
+   * Remove a green marker at the given path.
+   * @param {string} path dotted path such as 'UR.DR'
+   */
+  removeMarker(path) {
+    if (!this.svg) return;
+    const circle = this.tokenMap[path];
+    if (circle) {
+      circle.classList.remove('glyph-marker');
+    }
+  }
+
+  /**
    * Draw a connector line between two marker paths.
    * @param {string} firstPath
    * @param {string} secondPath
@@ -110,5 +122,17 @@ export default class TimelineDisplay {
     line.setAttribute('y2', p2.y);
     line.setAttribute('class', 'glyph-connector');
     this.svg.appendChild(line);
+    return line;
+  }
+
+  /**
+   * Remove a connector line that was previously added.
+   * @param {SVGLineElement} line
+   */
+  removeConnection(line) {
+    if (!line) return;
+    if (line.parentNode === this.svg) {
+      line.remove();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- track glyph actions and allow undoing last placement
- expose undo button and system hooks
- support removing timeline markers and connections

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c337cc8d2c8332950c8d3d0106a92b