### PR TITLE
Reset gesture button colors after glyph drop

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -178,6 +178,9 @@ export default class GlyphController {
       btn.addEventListener('dragover', (e) => e.preventDefault());
       btn.addEventListener('drop', (e) => {
         e.preventDefault();
+        const originalColor =
+          btn.dataset.originalColor || btn.style.backgroundColor;
+        btn.dataset.originalColor = originalColor;
         btn.style.backgroundColor = '#3fc009';
 
         const glyphId = e.dataTransfer.getData('text/plain');
@@ -379,6 +382,11 @@ export default class GlyphController {
             }
           });
         }
+
+        // Restore button color after the drop interaction completes
+        setTimeout(() => {
+          btn.style.backgroundColor = originalColor;
+        }, 300);
       });
     });
   }


### PR DESCRIPTION
## Summary
- Restore original background color of gesture buttons after glyph drops.
- Cache each button's initial color and reset it after drop interactions.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c3395080b883328e192ec8611383d8