### PR TITLE
Track button color persistence for glyph drops

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -235,6 +235,7 @@ export default class GlyphController {
             inputs: [first, second],
             markers: [],
             connectors: [],
+            buttons: [{ btn, originalColor }],
           };
           if (mark) {
             this.pendingPairMark = {
@@ -257,7 +258,10 @@ export default class GlyphController {
             inputs: [],
             markers: [],
             connectors: [],
+            buttons: [],
           };
+          record.buttons = record.buttons || [];
+          record.buttons.push({ btn, originalColor });
           const mark = this._markDisplay(name, ratio);
           if (mark && this.pendingPairMark) {
             if (mark.display !== this.pendingPairMark.display) {
@@ -329,6 +333,7 @@ export default class GlyphController {
               ? [{ display: mark.display, path: mark.path }]
               : [],
             connectors: [],
+            buttons: [{ btn, originalColor }],
           };
           this.actionStack.push(record);
         } else {
@@ -383,10 +388,6 @@ export default class GlyphController {
           });
         }
 
-        // Restore button color after the drop interaction completes
-        setTimeout(() => {
-          btn.style.backgroundColor = originalColor;
-        }, 300);
       });
     });
   }
@@ -404,6 +405,12 @@ export default class GlyphController {
           line.remove();
         }
       });
+      (this.pendingPairRecord.buttons || []).forEach(
+        ({ btn, originalColor }) => {
+          btn.style.backgroundColor = originalColor;
+          delete btn.dataset.originalColor;
+        }
+      );
       this.pendingPairRecord = null;
       this.pendingPairInput = null;
       this.pendingPairMark = null;
@@ -421,6 +428,10 @@ export default class GlyphController {
       } else if (line && typeof line.remove === 'function') {
         line.remove();
       }
+    });
+    (last.buttons || []).forEach(({ btn, originalColor }) => {
+      btn.style.backgroundColor = originalColor;
+      delete btn.dataset.originalColor;
     });
   }
 


### PR DESCRIPTION
## Summary
- keep gesture buttons highlighted after drop by storing their original colors
- record affected buttons in glyph action history
- restore button colors when undoing a glyph action

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c33c2d91c88332ba17ae8f8d9ecb4b