### PR TITLE
Replace alert with status message for gesture validation

### DIFF
--- a/src/ui/buttonPanelController.js
+++ b/src/ui/buttonPanelController.js
@@ -7,6 +7,7 @@ export default class ButtonPanelController {
     this.container = null;
     this.buttons = {};
     this.tempoInput = null;
+    this.statusMessage = null;
   }
 
   build() {
@@ -74,6 +75,19 @@ export default class ButtonPanelController {
     makeBtn('undoGlyph', 'Undo Glyph', 80);
     makeBtn('playSeq', 'Play Sequence', 120);
     makeBtn('nextSeq', 'Next Sequence', 120);
+
+    this.statusMessage = p
+      .createSpan('')
+      .style('margin-left', 'auto')
+      .style('font-size', '12px')
+      .style('color', '#b45309')
+      .style('min-height', '20px')
+      .style('display', 'flex')
+      .style('align-items', 'center')
+      .style('visibility', 'hidden')
+      .attribute('role', 'status')
+      .attribute('aria-live', 'polite')
+      .parent(this.container);
   }
 
   // Expose a getter so SystemUIController can read the input’s value
@@ -98,5 +112,11 @@ export default class ButtonPanelController {
 
   updateWeightsLabel(text) {
     this.buttons.toggleWeights.html(text);
+  }
+
+  updateStatusMessage(text) {
+    if (!this.statusMessage) return;
+    this.statusMessage.html(text || '');
+    this.statusMessage.style('visibility', text ? 'visible' : 'hidden');
   }
 }

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -163,7 +163,7 @@ export default class SystemUIController {
         validGestures,
         unresolved,
       });
-      alert(message);
+      this.buttonPanel.updateStatusMessage(message);
       this.systemRunning = false;
       this.buttonPanel.buttons.startStop.html('Go');
       this.timer.stop();
@@ -173,6 +173,7 @@ export default class SystemUIController {
     console.debug('Gesture tokens resolved:', validGestures);
 
     this.systemRunning = true;
+    this.buttonPanel.updateStatusMessage('System running');
     this.buttonPanel.buttons.startStop.html('Stop');
     this.spatialUIController.hideGestureButtons();
 
@@ -207,6 +208,7 @@ export default class SystemUIController {
   _stopSystem() {
     this.systemRunning = false;
     this.buttonPanel.buttons.startStop.html('Go');
+    this.buttonPanel.updateStatusMessage('System stopped');
     this.spatialUIController.showGestureButtons();
     this.timer.stop();
     this.spatialUIController.dotController.stop();


### PR DESCRIPTION
## Summary
- add a persistent status message element to the button panel for user feedback
- switch insufficient gesture handling to use the status message and update it on start/stop transitions

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc5998db40833280384ad0bf68b707