### PR TITLE
Add center positions to gesture map

### DIFF
--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -240,6 +240,7 @@ export default class SpatialUIController {
     const gesturePositions = {};
     this.allGestureObjects.forEach((obj) => {
       Object.assign(gesturePositions, obj.getPositions());
+      gesturePositions[obj.prefix] = { x: obj.center.x, y: obj.center.y };
     });
 
     // instantiate & initialize dot controller(s) exactly once


### PR DESCRIPTION
## Summary
- ensure each gesture object contributes its center point to the gesture position map
- allow gesture tokens like `L.R` and `R.R` to resolve without requiring a `.C` suffix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc5ca4779c8332b32ca4542c87dac9