### PR TITLE
Remove unused text inputs and buttons

### DIFF
--- a/src/ui/buttonPanelController.js
+++ b/src/ui/buttonPanelController.js
@@ -1,4 +1,4 @@
- // src/ui/ButtonPanelController.js
+// src/ui/ButtonPanelController.js
 
 export default class ButtonPanelController {
   constructor(p, handlers = {}) {
@@ -66,12 +66,8 @@ export default class ButtonPanelController {
 
     // Other controls
     makeBtn('startStop', 'Go', 60);
-    makeBtn('togglePopUp', 'Pop Up Mode: Off', 100);
-    makeBtn('toggleDuration', 'Duration: 8', 80);
     makeBtn('toggleWeights', 'Weights: Off', 100);
     makeBtn('copyState', 'Copy State', 80);
-    makeBtn('clearWeight', 'Clear Weight', 80);
-    makeBtn('clearGesture', 'Clear Gesture', 80);
     makeBtn('undoGlyph', 'Undo Glyph', 80);
     makeBtn('playSeq', 'Play Sequence', 120);
     makeBtn('nextSeq', 'Next Sequence', 120);
@@ -102,12 +98,6 @@ export default class ButtonPanelController {
 
   updateTimerModeLabel(text) {
     this.buttons.toggleTimerMode.html(text);
-  }
-  updatePopUpModeLabel(text) {
-    this.buttons.togglePopUp.html(text);
-  }
-  updateDurationLabel(text) {
-    this.buttons.toggleDuration.html(text);
   }
 
   updateWeightsLabel(text) {

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -86,20 +86,6 @@ export default class SystemUIController {
           this._startSystem();
         }
       },
-      togglePopUp: () => {
-        this.popUpMode = !this.popUpMode;
-        this.spatialUIController.dotController.setPopUpMode(this.popUpMode);
-        this.buttonPanel.updatePopUpModeLabel(
-          `Pop Up Mode: ${this.popUpMode ? 'On' : 'Off'}`
-        );
-      },
-      toggleDuration: () => {
-        this.duration = this.duration === 8 ? 4 : 8;
-        this.timer.setDuration(this.duration);
-        this.buttonPanel.updateDurationLabel(`Duration: ${this.duration}`);
-        this.textFieldController.updateLabels(this.timerMode, this.duration);
-        this.textFieldController.highlightActiveDot(this.activeDotIndex);
-      },
       toggleWeights: () => {
         this.weightsVisible = !this.weightsVisible;
         if (this.weightsVisible) {
@@ -115,8 +101,6 @@ export default class SystemUIController {
         this.activeDotIndex = dotIndex;
         this.textFieldController.highlightActiveDot(this.activeDotIndex);
       },
-      clearGesture: () => this._clearGestureInputs(this.activeDotIndex),
-      clearWeight: () => this._clearWeightInputs(),
       undoGlyph: () => this.glyphController?.undoLastGlyph(),
       copyState: () => this.copyState(),
       playSeq: () => this.loadFirstSequence(),
@@ -224,18 +208,6 @@ export default class SystemUIController {
     this.textFieldController.setGestureValues(primary, 0);
     this.textFieldController.setGestureValues(secondary, 1);
     this.textFieldController.setWeightValues(config.weightSeq || []);
-  }
-
-  _clearGestureInputs(dot = this.activeDotIndex) {
-    this.textFieldController?.clearGestures(dot);
-  }
-
-  _clearWeightInputs() {
-    this.textFieldController?.clearWeights();
-    this.weightSequence = [];
-    this.weightIndex = 0;
-    this.spatialUIController.orbControllers.L.clearHighlight();
-    this.spatialUIController.orbControllers.R.clearHighlight();
   }
 
   _startSystem() {
@@ -409,9 +381,6 @@ export default class SystemUIController {
     this.spatialUIController.dotController.setPopUpMode(
       normalizedConfig.popUpMode
     );
-    this.buttonPanel.updatePopUpModeLabel(
-      `Pop Up Mode: ${normalizedConfig.popUpMode ? 'On' : 'Off'}`
-    );
 
     // apply tempo & duration
     if (!isNaN(normalizedConfig.tempo)) {
@@ -422,9 +391,6 @@ export default class SystemUIController {
     if (!isNaN(normalizedConfig.duration)) {
       this.duration = normalizedConfig.duration;
       this.timer.setDuration(normalizedConfig.duration);
-      this.buttonPanel.updateDurationLabel(
-        `Duration: ${normalizedConfig.duration}`
-      );
     }
 
     if (this.textFieldController) {

--- a/src/ui/textFieldController.js
+++ b/src/ui/textFieldController.js
@@ -4,216 +4,139 @@ export default class TextFieldController {
   constructor(p, maxCols = 32) {
     this.p = p;
     this.maxCols = maxCols;
-    this.columns = []; // { inputTop, inputTop2, inputBottom, label }[]
-    this.container = null;
     this.visibleColumnCount = maxCols;
+
+    this.primaryValues = new Array(maxCols).fill('');
+    this.secondaryValues = new Array(maxCols).fill('');
+    this.weightValues = new Array(maxCols).fill('');
+    this.labels = new Array(maxCols).fill('');
+
+    this.highlightedIndex = null;
+    this.activeDot = 0;
   }
 
   build() {
-    const p = this.p;
-    this.container = p.createDiv()
-      .style('position', 'fixed')
-      // Move down to make room for a single gesture object plus padding
-      .style('top', 'calc(100px + 1.75 * 20px)')
-      .style('left', '0')
-      .style('width', '100%')
-      .style('height', '105px')
-      .style('background', 'rgba(255,255,255,0.8)')
-      .style('padding', '5px')
-      .style('display', 'flex')
-      .style('overflow-x', 'auto')
-      .style('z-index', '1000');
-
-    for (let i = 0; i < this.maxCols; i++) {
-      const col = p.createDiv()
-        .style('display','flex')
-        .style('flex-direction','column')
-        .style('align-items','center')
-        .style('margin-right','2px')
-        .parent(this.container);
-
-      const inputTop = p.createInput('')
-        // width sized to fit longest gesture name (e.g., "R.UR.UR")
-        .style('width', '56px')
-        .style('height', '20px')
-        .style('font-size', '8px')
-        .parent(col);
-
-      const inputTop2 = p.createInput('')
-        .style('width', '56px')
-        .style('height', '20px')
-        .style('font-size', '8px')
-        .parent(col);
-
-      const inputBottom = p.createInput('')
-        .style('width', '56px')
-        .style('height', '20px')
-        .style('font-size', '8px')
-        .parent(col);
-
-      const label = p.createSpan('')
-        .style('font-size', '8px')
-        .style('width', '56px')
-        .parent(col);
-
-      this.columns.push({ inputTop, inputTop2, inputBottom, label });
-    }
-
+    // The text boxes have been removed from the UI, but we keep the
+    // bookkeeping so existing logic can continue to function.
     this.updateLabels(0, 8);
-    this.highlightActiveDot(0);
   }
 
   updateLabels(timerMode, duration) {
     const headers = this._computeBeatHeaders(timerMode, duration);
     this.visibleColumnCount = headers.length;
-    this.columns.forEach((col, i) => {
-      if (i < headers.length) {
-        col.inputTop.show();
-        col.inputTop2.show();
-        col.inputBottom.show();
-        col.label.show();
-        col.label.html(headers[i]);
-      } else {
-        col.inputTop.hide();
-        col.inputTop2.hide();
-        col.inputBottom.hide();
-        col.label.hide();
-      }
-    });
-    this.clearHighlights();
-  }
 
-  getVisibleColumns() {
-    const count = Math.min(
-      this.visibleColumnCount ?? this.columns.length,
-      this.columns.length
-    );
-    return this.columns.slice(0, count);
+    this.labels.fill('');
+    headers.forEach((label, index) => {
+      this.labels[index] = label;
+    });
+
+    this.clearHighlights();
   }
 
   getGestureValues(dot = 0) {
-    const key = dot === 1 ? 'inputTop2' : 'inputTop';
-    return this.getVisibleColumns().map((c) => c[key].value().trim());
+    const source = dot === 1 ? this.secondaryValues : this.primaryValues;
+    return source.slice(0, this.visibleColumnCount).map((value) => value.trim());
   }
+
   getWeightValues() {
-    return this.getVisibleColumns().map((c) => c.inputBottom.value().trim());
+    return this.weightValues
+      .slice(0, this.visibleColumnCount)
+      .map((value) => value.trim());
   }
 
   setGestureValues(values = [], dot = 0) {
-    const key = dot === 1 ? 'inputTop2' : 'inputTop';
-    const cols = this.getVisibleColumns();
-    cols.forEach((col, i) => {
-      col[key].value(values[i] || '');
-    });
+    const target = dot === 1 ? this.secondaryValues : this.primaryValues;
+    for (let i = 0; i < this.maxCols; i++) {
+      target[i] = values[i]?.trim?.() || '';
+    }
   }
 
   setWeightValues(values = []) {
-    const cols = this.getVisibleColumns();
-    cols.forEach((col, i) => {
-      col.inputBottom.value(values[i] || '');
-    });
+    for (let i = 0; i < this.maxCols; i++) {
+      this.weightValues[i] = values[i]?.trim?.() || '';
+    }
   }
 
   clearGestures(dot = null) {
-    const targets = dot === null ? [0, 1] : [dot];
-    targets.forEach((idx) => {
-      const key = idx === 1 ? 'inputTop2' : 'inputTop';
-      this.columns.forEach((col) => {
-        col[key].value('');
-      });
-    });
+    if (dot === null) {
+      this.primaryValues.fill('');
+      this.secondaryValues.fill('');
+      return;
+    }
+
+    const target = dot === 1 ? this.secondaryValues : this.primaryValues;
+    target.fill('');
   }
 
   clearWeights() {
-    this.columns.forEach((col) => {
-      col.inputBottom.value('');
-    });
+    this.weightValues.fill('');
   }
 
   highlight(index) {
-    this.clearHighlights();
-    const columns = this.getVisibleColumns();
-    const filled = columns.filter(
-      (c) =>
-        c.inputTop.value().trim() ||
-        c.inputTop2.value().trim() ||
-        c.inputBottom.value().trim()
-    );
-    if (filled.length === 0) return;
-    const col = filled[index % filled.length];
-    col.inputTop.style('background-color', 'rgba(255,200,200,1)');
-    col.inputTop2.style('background-color', 'rgba(255,200,200,1)');
-    col.inputBottom.style('background-color', 'rgba(255,200,200,1)');
-    col.label.style('background-color', 'rgba(255,200,200,1)');
+    if (this.visibleColumnCount === 0) return;
+    this.highlightedIndex = index % this.visibleColumnCount;
   }
 
   highlightStep(index) {
-    this.clearHighlights();
-    const columns = this.getVisibleColumns();
-    const count = columns.length;
-    if (count === 0) return;
-    const idx = ((index % count) + count) % count;
-    const col = columns[idx];
-    col.inputTop.style('background-color', 'rgba(255,200,200,1)');
-    col.inputTop2.style('background-color', 'rgba(255,200,200,1)');
-    col.inputBottom.style('background-color', 'rgba(255,200,200,1)');
-    col.label.style('background-color', 'rgba(255,200,200,1)');
+    if (this.visibleColumnCount === 0) return;
+    const normalized = ((index % this.visibleColumnCount) + this.visibleColumnCount) % this.visibleColumnCount;
+    this.highlightedIndex = normalized;
   }
 
   clearHighlights() {
-    this.columns.forEach((c) => {
-      c.inputTop.style('background-color', 'white');
-      c.inputTop2.style('background-color', 'white');
-      c.inputBottom.style('background-color', 'white');
-      c.label.style('background-color', 'transparent');
-    });
+    this.highlightedIndex = null;
   }
 
-  // Visually indicate which dot row is active for editing
   highlightActiveDot(dot = 0) {
-    this.columns.forEach((c) => {
-      c.inputTop.style('outline', dot === 0 ? '2px solid blue' : 'none');
-      c.inputTop2.style('outline', dot === 1 ? '2px solid blue' : 'none');
-    });
+    this.activeDot = dot;
+  }
+
+  addGestureName(name, dot = 0) {
+    const target = dot === 1 ? this.secondaryValues : this.primaryValues;
+    const limit = this.visibleColumnCount || this.maxCols;
+    for (let i = 0; i < limit; i++) {
+      if (!target[i]) {
+        target[i] = name;
+        return;
+      }
+    }
+  }
+
+  addWeightName(name) {
+    const limit = this.visibleColumnCount || this.maxCols;
+    for (let i = 0; i < limit; i++) {
+      if (!this.weightValues[i]) {
+        this.weightValues[i] = name;
+        return;
+      }
+    }
   }
 
   _computeBeatHeaders(timerMode, duration) {
-    const subsMap = [1,2,2,4];
+    const subsMap = [1, 2, 2, 4];
     const subs = subsMap[timerMode] || 1;
     const maxCols = duration * subs;
     const headers = [];
     for (let i = 0; i < maxCols; i++) {
       let lbl;
       switch (timerMode) {
-        case 0: lbl = `${i+1}`; break;
-        case 1: lbl = i%2===0 ? `${i/2+1}` : 'and'; break;
-        case 2: lbl = i%2===0 ? 'and' : `${(i-1)/2+1}`; break;
-        case 3: lbl = ['1','e','and','a'][i%4]; break;
-        default: lbl = `${i+1}`;
+        case 0:
+          lbl = `${i + 1}`;
+          break;
+        case 1:
+          lbl = i % 2 === 0 ? `${i / 2 + 1}` : 'and';
+          break;
+        case 2:
+          lbl = i % 2 === 0 ? 'and' : `${(i - 1) / 2 + 1}`;
+          break;
+        case 3:
+          lbl = ['1', 'e', 'and', 'a'][i % 4];
+          break;
+        default:
+          lbl = `${i + 1}`;
       }
       headers.push(lbl);
     }
     return headers;
   }
-
-  addGestureName(name, dot = 0) {
-    const key = dot === 1 ? 'inputTop2' : 'inputTop';
-    for (const col of this.getVisibleColumns()) {
-      if (!col[key].value().trim()) {
-        col[key].value(name);
-        return;
-      }
-    }
-  }
-
-  /** Called by SpatialUIController when a weight button is pressed */
-  addWeightName(name) {
-    for (const col of this.getVisibleColumns()) {
-      if (!col.inputBottom.value().trim()) {
-        col.inputBottom.value(name);
-        return;
-      }
-    }
-  }
-
 }


### PR DESCRIPTION
## Summary
- remove the pop-up, duration, clear weight, and clear gesture controls from the button panel
- strip the TextFieldController of DOM text boxes while keeping gesture/weight bookkeeping
- update the system UI to reflect the reduced control surface

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc68b7042483329bad6587ff71af7f