### PR TITLE
Add glyph-aware dot controller

### DIFF
--- a/src/controllers/glyphDotController.js
+++ b/src/controllers/glyphDotController.js
@@ -1,0 +1,131 @@
+// src/controllers/glyphDotController.js
+
+import MultiDotController from './multiDotController.js';
+
+/**
+ * Multi-dot controller that keeps its gesture sequences in sync with
+ * the glyph-generated text boxes that live inside the selection bar.
+ */
+export default class GlyphDotController extends MultiDotController {
+  constructor(
+    p,
+    {
+      positionMap,
+      moveDurationMs = 500,
+      selectionBarElement = null,
+      selectionBarSelector = '#selection-bar',
+      autoSync = true,
+    }
+  ) {
+    super(p, { positionMap, moveDurationMs });
+
+    this.selectionBar = selectionBarElement;
+    if (!this.selectionBar && typeof selectionBarSelector === 'string') {
+      this.selectionBar = document.querySelector(selectionBarSelector);
+    } else if (
+      !this.selectionBar &&
+      typeof Element !== 'undefined' &&
+      selectionBarSelector instanceof Element
+    ) {
+      this.selectionBar = selectionBarSelector;
+    }
+
+    this.autoSync = autoSync;
+    this._fallbackSequences = [];
+    this._onGlyphChange = null;
+    this._observer = null;
+
+    if (this.selectionBar && this.autoSync) {
+      this._onGlyphChange = () => this.syncFromGlyphs();
+      this.selectionBar.addEventListener('glyph-change', this._onGlyphChange);
+      this.selectionBar.addEventListener('input', this._onGlyphChange, true);
+      if (typeof MutationObserver !== 'undefined') {
+        this._observer = new MutationObserver(() => this.syncFromGlyphs());
+        this._observer.observe(this.selectionBar, {
+          childList: true,
+          subtree: true,
+        });
+      }
+    }
+  }
+
+  /** Clean up DOM listeners/observers. */
+  dispose() {
+    if (this.selectionBar && this._onGlyphChange) {
+      this.selectionBar.removeEventListener('glyph-change', this._onGlyphChange);
+      this.selectionBar.removeEventListener('input', this._onGlyphChange, true);
+    }
+    if (this._observer) {
+      this._observer.disconnect();
+      this._observer = null;
+    }
+  }
+
+  /** Store the last explicit sequences as a fallback. */
+  loadSequences(sequences = []) {
+    this._fallbackSequences = sequences.map((seq) => seq.slice());
+    super.loadSequences(sequences);
+  }
+
+  /** Pull sequences from the glyph selection bar, falling back when empty. */
+  syncFromGlyphs() {
+    const glyphSequences = this._extractSequencesFromSelectionBar();
+
+    if (glyphSequences.length > 0) {
+      super.loadSequences(glyphSequences);
+    } else if (this._fallbackSequences.length > 0) {
+      super.loadSequences(this._fallbackSequences.map((seq) => seq.slice()));
+    } else {
+      super.loadSequences([]);
+    }
+  }
+
+  /**
+   * Convert the selection bar inputs into gesture sequences (one per prefix).
+   * The order of inputs is preserved and sequences are grouped by their
+   * top-level token (e.g. 'L' vs 'R').
+   */
+  _extractSequencesFromSelectionBar() {
+    if (!this.selectionBar) return [];
+
+    const inputs = Array.from(
+      this.selectionBar.querySelectorAll('input[type="text"]')
+    );
+    if (inputs.length === 0) return [];
+
+    const trackMap = new Map();
+
+    inputs.forEach((input) => {
+      const token = (input.value || '').trim();
+      if (!token) return;
+
+      const root = token.split('.')[0];
+      if (!root) return;
+
+      if (!trackMap.has(root)) {
+        trackMap.set(root, []);
+      }
+      trackMap.get(root).push(token);
+    });
+
+    if (trackMap.size === 0) return [];
+
+    const orderedPrefixes = ['L', 'R'];
+    const sequences = [];
+
+    orderedPrefixes.forEach((prefix) => {
+      if (trackMap.has(prefix)) {
+        sequences.push(trackMap.get(prefix));
+        trackMap.delete(prefix);
+      }
+    });
+
+    Array.from(trackMap.keys())
+      .sort()
+      .forEach((prefix) => {
+        sequences.push(trackMap.get(prefix));
+      });
+
+    return sequences;
+  }
+}

--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -86,6 +86,11 @@ export default class GlyphController {
     this._setupDropTargets();
   }
 
+  _notifyGlyphChange() {
+    if (!this.bar) return;
+    this.bar.dispatchEvent(new CustomEvent('glyph-change'));
+  }
+
   _setupGlyphs() {
     document.addEventListener('dragstart', (e) => {
       const glyph = e.target.closest(this.glyphSelector);
@@ -388,6 +393,8 @@ export default class GlyphController {
           });
         }
 
+        this._notifyGlyphChange();
+
       });
     });
   }
@@ -415,6 +422,7 @@ export default class GlyphController {
       this.pendingPairInput = null;
       this.pendingPairMark = null;
       this._centerSelectionBar();
+      this._notifyGlyphChange();
       return;
     }
     const last = this.actionStack.pop();
@@ -433,6 +441,7 @@ export default class GlyphController {
       btn.style.backgroundColor = originalColor;
       delete btn.dataset.originalColor;
     });
+    this._notifyGlyphChange();
   }
 
   _centerSelectionBar() {

--- a/src/ui/spatialUIController.js
+++ b/src/ui/spatialUIController.js
@@ -1,6 +1,6 @@
  // src/ui/spatialUIController.js
 
-import MultiDotController from '../controllers/multiDotController.js';
+import GlyphDotController from '../controllers/glyphDotController.js';
 import OrbController from '../controllers/orbController.js';
 
 export default class SpatialUIController {
@@ -244,14 +244,16 @@ export default class SpatialUIController {
     });
 
     // instantiate & initialize dot controller(s) exactly once
-    this.dotController = new MultiDotController(this.p, {
+    this.dotController = new GlyphDotController(this.p, {
       positionMap: gesturePositions,
       moveDurationMs: 500,
+      selectionBarSelector: '#selection-bar',
     });
     this.dotController.loadSequences([
       ['L.C', 'L.U', 'L.D', 'L.L', 'L.R'],
       ['R.C', 'R.U', 'R.D', 'R.L', 'R.R'],
     ]);
+    this.dotController.syncFromGlyphs();
   }
 
   render(dt) {


### PR DESCRIPTION
## Summary
- create a glyph-aware dot controller that can derive gesture sequences from the selection bar inputs
- wire the spatial UI to the new controller and dispatch glyph-change events from the glyph controller so the dot stays in sync

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6ad1ad9c8332979f0bc43c1be138