### PR TITLE
Sync glyph sequences with system config

### DIFF
--- a/src/controllers/glyphDotController.js
+++ b/src/controllers/glyphDotController.js
@@ -67,6 +67,18 @@ export default class GlyphDotController extends MultiDotController {
     super.loadSequences(sequences);
   }
 
+  /**
+   * Return the current glyph sequences, falling back to the last stored
+   * sequences if the selection bar is empty.
+   */
+  getGlyphSequences() {
+    const glyphSequences = this._extractSequencesFromSelectionBar();
+    if (glyphSequences.length > 0) {
+      return glyphSequences.map((sequence) => sequence.slice());
+    }
+    return this._fallbackSequences.map((seq) => seq.slice());
+  }
+
   /** Pull sequences from the glyph selection bar, falling back when empty. */
   syncFromGlyphs() {
     const glyphSequences = this._extractSequencesFromSelectionBar();

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -174,11 +174,24 @@ export default class SystemUIController {
       gestureSeqs.push(normalizedSecondary);
     }
 
-    const gestureSeq = primaryHasTokens
+    let gestureSeq = primaryHasTokens
       ? normalizedPrimary
       : secondaryHasTokens
       ? normalizedSecondary
       : normalizedPrimary;
+
+    if (gestureSeqs.length === 0) {
+      const dotController = this.spatialUIController?.dotController;
+      if (dotController && typeof dotController.getGlyphSequences === 'function') {
+        const glyphSequences = dotController.getGlyphSequences();
+        if (glyphSequences.length > 0) {
+          glyphSequences.forEach((sequence) => {
+            gestureSeqs.push(normalizeGestureSequence(sequence));
+          });
+          gestureSeq = gestureSeqs[0] || [];
+        }
+      }
+    }
 
     const config = {
       measure: null,
@@ -223,12 +236,22 @@ export default class SystemUIController {
       }
     }
 
-    const positionMap =
-      this.spatialUIController.dotController?.positionMap || {};
-    const rawSequences =
+    const dotController = this.spatialUIController.dotController;
+    const positionMap = dotController?.positionMap || {};
+    let rawSequences =
       this.currentConfig.gestureSeqs && this.currentConfig.gestureSeqs.length > 0
         ? this.currentConfig.gestureSeqs
         : [this.currentConfig.gestureSeq || []];
+
+    const hasGestureTokens = rawSequences.some(
+      (sequence) => sequence && sequence.some((token) => token)
+    );
+    if (!hasGestureTokens && dotController && typeof dotController.getGlyphSequences === 'function') {
+      const glyphSequences = dotController.getGlyphSequences();
+      if (glyphSequences.length > 0) {
+        rawSequences = glyphSequences;
+      }
+    }
 
     const resolvedSequences = rawSequences.map((sequence, index) => {
       const valid = [];


### PR DESCRIPTION
## Summary
- add a helper on GlyphDotController to expose the current glyph-generated gesture sequences with a fallback to stored sequences
- extend SystemUIController to pull glyph gestures into the captured config when the legacy text fields are empty
- make system startup fall back to glyph-backed sequences so the dot controller and timers follow the glyph path

## Testing
- no automated tests were run (project has no test suite)


------
https://chatgpt.com/codex/tasks/task_e_68cc6e757298833292a85cdc46b24fa2