### PR TITLE
Add Lock Sequence button placeholder

### DIFF
--- a/src/ui/buttonPanelController.js
+++ b/src/ui/buttonPanelController.js
@@ -68,6 +68,7 @@ export default class ButtonPanelController {
     makeBtn('glyphGo', 'Glyph Go', 80);
     makeBtn('toggleWeights', 'Weights: Off', 100);
     makeBtn('copyState', 'Copy State', 80);
+    makeBtn('lockSequence', 'Lock Sequence', 110);
     makeBtn('undoGlyph', 'Undo Glyph', 80);
     makeBtn('playSeq', 'Play Sequence', 120);
     makeBtn('nextSeq', 'Next Sequence', 120);

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -102,6 +102,7 @@ export default class SystemUIController {
       },
       undoGlyph: () => this.glyphController?.undoLastGlyph(),
       copyState: () => this.copyState(),
+      lockSequence: () => this.lockCurrentSequence(),
       playSeq: () => this.loadFirstSequence(),
       nextSeq: () => this.loadNextSequence(),
     });
@@ -141,6 +142,11 @@ export default class SystemUIController {
         this.stepIndex = (this.stepIndex + 1) % this.totalStepCount;
       }
     });
+  }
+
+  lockCurrentSequence() {
+    console.log('[SystemUI] Lock Sequence clicked');
+    this.buttonPanel?.updateStatusMessage('Sequence locked (placeholder)');
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a Lock Sequence button to the bottom control panel for timeline interactions
- wire the new button to a SystemUI handler stub that updates the UI status message for now

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d02826d3a08332b7b7aa5026b9f6ae