### PR TITLE
Add sequence grouping helper and lock workflow

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -1,3 +1,5 @@
+import Sequence from './sequence.js';
+
 class SingleBlueGlyph {
   constructor(left, top, anchor) {
     const div = document.createElement('div');
@@ -67,6 +69,8 @@ export default class GlyphController {
     this.dragOffset = { x: 0, y: 0 };
     this.otherCircleOffset = null;
     this.actionStack = [];
+    this.sequences = [];
+    this.activeSequence = null;
     if (this.bar) {
       this._centerSelectionBar();
       window.addEventListener('resize', () => this._centerSelectionBar());
@@ -82,6 +86,7 @@ export default class GlyphController {
       this.glyph2Template.removeAttribute('id');
     }
     if (!this.glyphs.length || !this.bar) return;
+    this._ensureActiveSequence();
     this._setupGlyphs();
     this._setupDropTargets();
   }
@@ -193,6 +198,10 @@ export default class GlyphController {
         const prong = e.dataTransfer.getData('prong');
         const isSingleBlue = glyphId === 'singleBlueGlyph';
 
+        const sequence =
+          this.pendingPairRecord?.sequence || this._ensureActiveSequence();
+        if (!sequence) return;
+
         if (glyphId === 'glyph' && !prong && this.currentGlyph) {
           this.currentGlyph.removeAttribute('id');
           this.currentGlyph.style.width = '15px';
@@ -232,8 +241,8 @@ export default class GlyphController {
           second.style.fontSize = '8px';
           second.style.height = '20px';
           second.value = '';
-          this.bar.appendChild(first);
-          this.bar.appendChild(second);
+          sequence.adopt(first);
+          sequence.adopt(second);
           this._centerSelectionBar();
           const mark = this._markDisplay(name, ratio);
           const record = {
@@ -242,6 +251,7 @@ export default class GlyphController {
             connectors: [],
             buttons: [{ btn, originalColor }],
           };
+          sequence.addRecord(record);
           if (mark) {
             this.pendingPairMark = {
               display: mark.display,
@@ -265,6 +275,9 @@ export default class GlyphController {
             connectors: [],
             buttons: [],
           };
+          if (!record.sequence) {
+            sequence.addRecord(record);
+          }
           record.buttons = record.buttons || [];
           record.buttons.push({ btn, originalColor });
           const mark = this._markDisplay(name, ratio);
@@ -325,7 +338,7 @@ export default class GlyphController {
           if (glyphId) {
             input.dataset.glyph = glyphId;
           }
-          this.bar.appendChild(input);
+          sequence.adopt(input);
           this._centerSelectionBar();
           const mark = this._markDisplay(name, ratio);
           if (this.currentGlyph) {
@@ -340,6 +353,7 @@ export default class GlyphController {
             connectors: [],
             buttons: [{ btn, originalColor }],
           };
+          sequence.addRecord(record);
           this.actionStack.push(record);
         } else {
           // existing logic to spawn another text box is skipped
@@ -401,6 +415,7 @@ export default class GlyphController {
 
   undoLastGlyph() {
     if (this.pendingPairRecord) {
+      const sequence = this.pendingPairRecord.sequence;
       this.pendingPairRecord.inputs.forEach((el) => el.remove());
       this.pendingPairRecord.markers.forEach(({ display, path }) =>
         display.removeMarker(path)
@@ -418,6 +433,13 @@ export default class GlyphController {
           delete btn.dataset.originalColor;
         }
       );
+      if (sequence) {
+        sequence.removeRecord(this.pendingPairRecord);
+        if (sequence === this.activeSequence && sequence.destroyIfEmpty()) {
+          this._removeSequence(sequence);
+          this._ensureActiveSequence();
+        }
+      }
       this.pendingPairRecord = null;
       this.pendingPairInput = null;
       this.pendingPairMark = null;
@@ -441,7 +463,45 @@ export default class GlyphController {
       btn.style.backgroundColor = originalColor;
       delete btn.dataset.originalColor;
     });
+    const { sequence } = last;
+    if (sequence) {
+      sequence.removeRecord(last);
+      if (sequence === this.activeSequence && sequence.destroyIfEmpty()) {
+        this._removeSequence(sequence);
+        this._ensureActiveSequence();
+      }
+    }
     this._notifyGlyphChange();
+  }
+
+  lockActiveSequence() {
+    if (!this.activeSequence) {
+      return { success: false, reason: 'No active sequence to lock.' };
+    }
+    if (this.pendingPairInput || this.pendingPairRecord) {
+      return {
+        success: false,
+        reason: 'Finish pairing the current glyph before locking.',
+      };
+    }
+    if (this.activeSequence.isEmpty()) {
+      if (this.activeSequence.destroyIfEmpty()) {
+        this._removeSequence(this.activeSequence);
+        this.activeSequence = this._ensureActiveSequence();
+        this._centerSelectionBar();
+      }
+      return { success: false, reason: 'Add glyphs before locking the set.' };
+    }
+
+    this.activeSequence.lock();
+    this.actionStack = [];
+    this.activeSequence = null;
+    const next = this._ensureActiveSequence();
+    if (next) {
+      this._centerSelectionBar();
+    }
+    this._notifyGlyphChange();
+    return { success: true, reason: 'Sequence locked.' };
   }
 
   _centerSelectionBar() {
@@ -531,5 +591,29 @@ export default class GlyphController {
       return { display, path };
     }
     return null;
+  }
+
+  _ensureActiveSequence() {
+    if (!this.bar) return null;
+    if (this.activeSequence && this.activeSequence.element.isConnected) {
+      return this.activeSequence;
+    }
+    return this._createSequence();
+  }
+
+  _createSequence() {
+    if (!this.bar) return null;
+    const sequence = new Sequence(this.bar);
+    this.sequences.push(sequence);
+    this.activeSequence = sequence;
+    this._centerSelectionBar();
+    return sequence;
+  }
+
+  _removeSequence(sequence) {
+    this.sequences = this.sequences.filter((item) => item !== sequence);
+    if (this.activeSequence === sequence) {
+      this.activeSequence = null;
+    }
   }
 }

--- a/src/ui/sequence.js
+++ b/src/ui/sequence.js
@@ -1,0 +1,67 @@
+export default class Sequence {
+  constructor(bar) {
+    this.bar = bar;
+    this.element = document.createElement('div');
+    this.element.className = 'sequence-group';
+    this.element.dataset.state = 'active';
+    this.records = [];
+    this.inputs = new Set();
+    if (this.bar) {
+      this.bar.appendChild(this.element);
+    }
+  }
+
+  adopt(element) {
+    if (!element) return;
+    this.element.appendChild(element);
+    if (element.tagName === 'INPUT') {
+      this.inputs.add(element);
+    }
+  }
+
+  addRecord(record) {
+    if (!record || this.records.includes(record)) return;
+    this.records.push(record);
+    record.sequence = this;
+    (record.inputs || []).forEach((input) => {
+      if (input && input.tagName === 'INPUT') {
+        this.inputs.add(input);
+      }
+    });
+  }
+
+  removeRecord(record) {
+    const index = this.records.indexOf(record);
+    if (index !== -1) {
+      this.records.splice(index, 1);
+    }
+    (record.inputs || []).forEach((input) => {
+      if (input && !input.isConnected) {
+        this.inputs.delete(input);
+      }
+    });
+  }
+
+  isEmpty() {
+    if (!this.element.isConnected) return true;
+    const remainingInputs = Array.from(this.inputs).filter((input) =>
+      input && input.isConnected && this.element.contains(input)
+    );
+    this.inputs = new Set(remainingInputs);
+    return remainingInputs.length === 0;
+  }
+
+  lock() {
+    this.element.dataset.state = 'locked';
+  }
+
+  destroyIfEmpty() {
+    if (!this.isEmpty()) {
+      return false;
+    }
+    this.element.remove();
+    this.records.length = 0;
+    this.inputs.clear();
+    return true;
+  }
+}

--- a/src/ui/systemUIController.js
+++ b/src/ui/systemUIController.js
@@ -146,7 +146,32 @@ export default class SystemUIController {
 
   lockCurrentSequence() {
     console.log('[SystemUI] Lock Sequence clicked');
-    this.buttonPanel?.updateStatusMessage('Sequence locked (placeholder)');
+    if (
+      !this.glyphController ||
+      typeof this.glyphController.lockActiveSequence !== 'function'
+    ) {
+      this.buttonPanel?.updateStatusMessage('Locking is not available yet.');
+      return;
+    }
+
+    const result = this.glyphController.lockActiveSequence();
+    const { success, reason } = result || {};
+    const friendlyReasons = {
+      'No active sequence to lock.': 'No active sequence is ready to lock yet.',
+      'Finish pairing the current glyph before locking.':
+        'Complete the current pair before locking the sequence.',
+      'Add glyphs before locking the set.':
+        'Add at least one glyph before locking the sequence.',
+    };
+
+    if (success) {
+      this.buttonPanel?.updateStatusMessage('Sequence locked!');
+    } else {
+      const message =
+        friendlyReasons[reason] || reason ||
+        'Unable to lock the current sequence.';
+      this.buttonPanel?.updateStatusMessage(message);
+    }
   }
 
   /**

--- a/styles.css
+++ b/styles.css
@@ -78,9 +78,28 @@ h1 {
     top: 130px;
     left: 50%;
     display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: center;
     gap: 6px;
     padding: 6px;
     z-index: 1000;
+}
+
+.sequence-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 6px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px solid transparent;
+}
+
+.sequence-group[data-state="locked"] {
+    border: 2px solid rgba(236, 72, 153, 0.45);
+    background: rgba(255, 255, 255, 0.5);
 }
 
 #timeline-wrapper {


### PR DESCRIPTION
## Summary
- add a reusable Sequence helper that manages grouped selection bar containers
- refactor the glyph controller to build glyph inputs through the active sequence, support locking, and clean up undo behaviour
- update the system UI and styles so locked sequences are highlighted and user feedback reflects the new workflow

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d02bed97f4833289dc9b760616d005