### PR TITLE
Exclude locked glyph sequences from playback

### DIFF
--- a/src/controllers/glyphDotController.js
+++ b/src/controllers/glyphDotController.js
@@ -102,7 +102,10 @@ export default class GlyphDotController extends MultiDotController {
 
     const inputs = Array.from(
       this.selectionBar.querySelectorAll('input[type="text"]')
-    );
+    ).filter((input) => {
+      const group = input.closest('.sequence-group');
+      return !group || group.dataset.state !== 'locked';
+    });
     if (inputs.length === 0) return [];
 
     const trackMap = new Map();


### PR DESCRIPTION
## Summary
- ignore glyph inputs that belong to locked sequences when gathering selection bar tokens

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d02f8adbd48332a0ee66fbf2ebeeb5