### PR TITLE
Reposition sequence groups around timeline

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -519,8 +519,7 @@ export default class GlyphController {
 
   _centerSelectionBar() {
     if (!this.bar) return;
-    const width = this.bar.getBoundingClientRect().width;
-    this.bar.style.marginLeft = `-${width / 2}px`;
+    this.bar.style.marginLeft = '0px';
   }
 
   _spawnSingleGlyph(left, top, anchor) {

--- a/src/ui/sequence.js
+++ b/src/ui/sequence.js
@@ -1,13 +1,47 @@
+const BAR_CONTAINERS = new WeakMap();
+
+function ensureContainers(bar) {
+  if (!bar) return { activeContainer: null, lockedContainer: null };
+
+  let containers = BAR_CONTAINERS.get(bar);
+  if (containers) {
+    return containers;
+  }
+
+  const lockedContainer =
+    bar.querySelector('[data-role="locked-sequences"]') ||
+    document.createElement('div');
+  if (!lockedContainer.dataset.role) {
+    lockedContainer.dataset.role = 'locked-sequences';
+    bar.appendChild(lockedContainer);
+  }
+
+  const activeContainer =
+    bar.querySelector('[data-role="active-sequence"]') ||
+    document.createElement('div');
+  if (!activeContainer.dataset.role) {
+    activeContainer.dataset.role = 'active-sequence';
+    bar.appendChild(activeContainer);
+  }
+
+  containers = { activeContainer, lockedContainer };
+  BAR_CONTAINERS.set(bar, containers);
+  return containers;
+}
+
 export default class Sequence {
   constructor(bar) {
     this.bar = bar;
+    const { activeContainer, lockedContainer } = ensureContainers(this.bar);
+    this.activeContainer = activeContainer;
+    this.lockedContainer = lockedContainer;
     this.element = document.createElement('div');
     this.element.className = 'sequence-group';
     this.element.dataset.state = 'active';
     this.records = [];
     this.inputs = new Set();
-    if (this.bar) {
-      this.bar.appendChild(this.element);
+    if (this.activeContainer) {
+      this.activeContainer.appendChild(this.element);
     }
   }
 
@@ -53,6 +87,9 @@ export default class Sequence {
 
   lock() {
     this.element.dataset.state = 'locked';
+    if (this.lockedContainer && this.element.parentElement !== this.lockedContainer) {
+      this.lockedContainer.appendChild(this.element);
+    }
   }
 
   destroyIfEmpty() {

--- a/styles.css
+++ b/styles.css
@@ -75,15 +75,40 @@ h1 {
 
 #selection-bar {
     position: fixed;
-    top: 130px;
+    top: 150px;
     left: 50%;
-    display: flex;
-    flex-wrap: wrap;
+    transform: translateX(-50%);
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: flex-start;
-    justify-content: center;
-    gap: 6px;
-    padding: 6px;
+    column-gap: 16px;
+    row-gap: 12px;
+    padding: 6px 12px;
+    width: min(960px, calc(100vw - 40px));
     z-index: 1000;
+}
+
+#selection-bar [data-role="locked-sequences"] {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    grid-column: 1;
+}
+
+#selection-bar [data-role="active-sequence"] {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    grid-column: 2;
+}
+
+#selection-bar [data-role="active-sequence"] .sequence-group {
+    margin: 0 auto;
+}
+
+#selection-bar [data-role="locked-sequences"] .sequence-group {
+    align-self: flex-start;
 }
 
 .sequence-group {


### PR DESCRIPTION
## Summary
- add dedicated containers for active and locked sequences so the open group can stay centered under the timeline
- update the selection bar layout to use a centered grid with the active sequence in the middle column and locked sequences stacked on the left
- stop applying dynamic margin offsets because CSS centering now handles alignment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d030d5058483328fcf6f1b8025b42d