### PR TITLE
Clear timeline markers when locking sequence

### DIFF
--- a/src/ui/glyphController.js
+++ b/src/ui/glyphController.js
@@ -493,6 +493,7 @@ export default class GlyphController {
       return { success: false, reason: 'Add glyphs before locking the set.' };
     }
 
+    this._clearTimelineForSequence(this.activeSequence);
     this.activeSequence.lock();
     this.actionStack = [];
     this._resetGestureButtonColors();
@@ -514,6 +515,28 @@ export default class GlyphController {
       } else {
         btn.style.removeProperty('background-color');
       }
+    });
+  }
+
+  _clearTimelineForSequence(sequence) {
+    if (!sequence || !Array.isArray(sequence.records)) {
+      return;
+    }
+
+    sequence.records.forEach((record) => {
+      (record.markers || []).forEach(({ display, path }) => {
+        if (display && typeof display.removeMarker === 'function') {
+          display.removeMarker(path);
+        }
+      });
+
+      (record.connectors || []).forEach(({ line, display }) => {
+        if (display && typeof display.removeConnection === 'function') {
+          display.removeConnection(line);
+        } else if (line && typeof line.remove === 'function') {
+          line.remove();
+        }
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- remove timeline markers and connector lines when the active sequence is locked
- add a helper to clear markers and connectors recorded on the sequence

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0330413e08332a68d3710c0f1518e