### PR TITLE
Keep locked sequences in a single row

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -90,7 +90,8 @@ h1 {
 
 #selection-bar [data-role="locked-sequences"] {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: nowrap;
     align-items: flex-start;
     gap: 6px;
     grid-column: 1;


### PR DESCRIPTION
## Summary
- ensure the locked sequences container uses a horizontal flex layout so groups stay on one line

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0349fc46c833288e5da5b1d609646