### PR TITLE
Enable horizontal scrolling for sequence inputs

### DIFF
--- a/src/ui/sequence.js
+++ b/src/ui/sequence.js
@@ -40,6 +40,25 @@ export default class Sequence {
     this.element.dataset.state = 'active';
     this.records = [];
     this.inputs = new Set();
+    this.element.addEventListener(
+      'wheel',
+      (event) => {
+        if (event.ctrlKey) return;
+        const target = event.currentTarget;
+        if (!(target instanceof HTMLElement)) return;
+        if (target.scrollWidth <= target.clientWidth) return;
+
+        const delta =
+          Math.abs(event.deltaY) > Math.abs(event.deltaX)
+            ? event.deltaY
+            : event.deltaX;
+        if (delta === 0) return;
+
+        event.preventDefault();
+        target.scrollLeft += delta;
+      },
+      { passive: false }
+    );
     if (this.activeContainer) {
       this.activeContainer.appendChild(this.element);
     }

--- a/styles.css
+++ b/styles.css
@@ -114,13 +114,20 @@ h1 {
 
 .sequence-group {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
     gap: 6px;
     padding: 6px;
     border-radius: 8px;
     background: rgba(255, 255, 255, 0.8);
     border: 1px solid transparent;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+}
+
+.sequence-group::-webkit-scrollbar {
+    display: none;
 }
 
 .sequence-group[data-state="locked"] {


### PR DESCRIPTION
## Summary
- update sequence group styling to keep glyph inputs at full size while allowing horizontal overflow
- add a wheel handler that scrolls sequence groups horizontally so hover scrolling replaces wrapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03638d8c08332a98eb3b903ef166d