### PR TITLE
Keep locked sequences panel from overlapping widget

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -79,7 +79,7 @@ h1 {
     left: 50%;
     transform: translateX(-50%);
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
     align-items: flex-start;
     column-gap: 16px;
     row-gap: 12px;
@@ -95,6 +95,14 @@ h1 {
     align-items: flex-start;
     gap: 6px;
     grid-column: 1;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+}
+
+#selection-bar [data-role="locked-sequences"]::-webkit-scrollbar {
+    display: none;
 }
 
 #selection-bar [data-role="active-sequence"] {


### PR DESCRIPTION
## Summary
- constrain the selection bar grid so the locked sequence column can shrink instead of overlapping the widget
- enable horizontal scrolling on the locked sequence container and hide scrollbars to keep the section aligned left while remaining usable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d037b0816c8332b0bae8725fc683d5