### PR TITLE
Adjust sequence scroll handling

### DIFF
--- a/src/ui/sequence.js
+++ b/src/ui/sequence.js
@@ -40,25 +40,6 @@ export default class Sequence {
     this.element.dataset.state = 'active';
     this.records = [];
     this.inputs = new Set();
-    this.element.addEventListener(
-      'wheel',
-      (event) => {
-        if (event.ctrlKey) return;
-        const target = event.currentTarget;
-        if (!(target instanceof HTMLElement)) return;
-        if (target.scrollWidth <= target.clientWidth) return;
-
-        const delta =
-          Math.abs(event.deltaY) > Math.abs(event.deltaX)
-            ? event.deltaY
-            : event.deltaX;
-        if (delta === 0) return;
-
-        event.preventDefault();
-        target.scrollLeft += delta;
-      },
-      { passive: false }
-    );
     if (this.activeContainer) {
       this.activeContainer.appendChild(this.element);
     }

--- a/styles.css
+++ b/styles.css
@@ -129,13 +129,7 @@ h1 {
     border-radius: 8px;
     background: rgba(255, 255, 255, 0.8);
     border: 1px solid transparent;
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none;
-}
-
-.sequence-group::-webkit-scrollbar {
-    display: none;
+    flex: 0 0 auto;
 }
 
 .sequence-group[data-state="locked"] {


### PR DESCRIPTION
## Summary
- stop attaching a wheel handler to individual sequence containers so they no longer scroll themselves
- update sequence styling to remove internal overflow and rely on the surrounding scroll area while keeping each group from shrinking

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d038d09f3c8332b83a239eab1a8955