### PR TITLE
Expand selection bar to screen edge

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -76,15 +76,16 @@ h1 {
 #selection-bar {
     position: fixed;
     top: 150px;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    right: 0;
+    transform: none;
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
     align-items: flex-start;
     column-gap: 16px;
     row-gap: 12px;
     padding: 6px 12px;
-    width: min(960px, calc(100vw - 40px));
+    width: 100%;
     z-index: 1000;
 }
 


### PR DESCRIPTION
## Summary
- stretch the selection bar overlay to span the full viewport width
- allow the locked sequence scroller to reach the left edge of the screen

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d03b3ffa088332a7d81ef6352f8c36