### PR TITLE
Adjust selection bar layout spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -75,12 +75,12 @@ h1 {
 
 #selection-bar {
     position: fixed;
-    top: 150px;
+    top: 165px;
     left: 0;
     right: 0;
     transform: none;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(520px, max-content) minmax(0, 1fr);
     align-items: flex-start;
     column-gap: 16px;
     row-gap: 12px;
@@ -97,6 +97,7 @@ h1 {
     gap: 6px;
     grid-column: 1;
     min-width: 0;
+    max-width: max(0px, calc((100% - 520px - 32px) / 2));
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none;
@@ -111,6 +112,7 @@ h1 {
     justify-content: center;
     align-items: flex-start;
     grid-column: 2;
+    min-width: 520px;
 }
 
 #selection-bar [data-role="active-sequence"] .sequence-group {


### PR DESCRIPTION
## Summary
- raise the selection bar to maintain clear space below the timelines and reserve a 520px center column for eight textboxes
- constrain the locked-sequence rail and active sequence area widths so their layouts do not overlap the open sequence inputs

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03e61a7ec8332a1e7a43af2e260aa